### PR TITLE
fix: rename Go package and log file to 'fibrumpdf'

### DIFF
--- a/go/cmd/tojson/main.go
+++ b/go/cmd/tojson/main.go
@@ -17,9 +17,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/pymupdf4llm-c/go/internal/bridge"
-	"github.com/pymupdf4llm-c/go/internal/extractor"
-	"github.com/pymupdf4llm-c/go/internal/logger"
+	"github.com/fibrumpdf/go/internal/bridge"
+	"github.com/fibrumpdf/go/internal/extractor"
+	"github.com/fibrumpdf/go/internal/logger"
 )
 
 var Logger = logger.GetLogger("tomd")

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/pymupdf4llm-c/go
+module github.com/fibrumpdf/go
 
 go 1.21
 

--- a/go/internal/bridge/bridge.go
+++ b/go/internal/bridge/bridge.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"unsafe"
 
-	"github.com/pymupdf4llm-c/go/internal/logger"
+	"github.com/fibrumpdf/go/internal/logger"
 )
 
 var Logger = logger.GetLogger("bridge")

--- a/go/internal/column/column.go
+++ b/go/internal/column/column.go
@@ -1,8 +1,8 @@
 package column
 
 import (
-	"github.com/pymupdf4llm-c/go/internal/geometry"
-	"github.com/pymupdf4llm-c/go/internal/models"
+	"github.com/fibrumpdf/go/internal/geometry"
+	"github.com/fibrumpdf/go/internal/models"
 )
 
 const (

--- a/go/internal/extractor/cleanup.go
+++ b/go/internal/extractor/cleanup.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pymupdf4llm-c/go/internal/models"
-	"github.com/pymupdf4llm-c/go/internal/text"
+	"github.com/fibrumpdf/go/internal/models"
+	"github.com/fibrumpdf/go/internal/text"
 )
 
 type CleanupOpts struct {

--- a/go/internal/extractor/extractor.go
+++ b/go/internal/extractor/extractor.go
@@ -5,13 +5,13 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pymupdf4llm-c/go/internal/bridge"
-	"github.com/pymupdf4llm-c/go/internal/column"
-	"github.com/pymupdf4llm-c/go/internal/geometry"
-	"github.com/pymupdf4llm-c/go/internal/logger"
-	"github.com/pymupdf4llm-c/go/internal/models"
-	"github.com/pymupdf4llm-c/go/internal/table"
-	"github.com/pymupdf4llm-c/go/internal/text"
+	"github.com/fibrumpdf/go/internal/bridge"
+	"github.com/fibrumpdf/go/internal/column"
+	"github.com/fibrumpdf/go/internal/geometry"
+	"github.com/fibrumpdf/go/internal/logger"
+	"github.com/fibrumpdf/go/internal/models"
+	"github.com/fibrumpdf/go/internal/table"
+	"github.com/fibrumpdf/go/internal/text"
 )
 
 var Logger = logger.GetLogger("extractor")

--- a/go/internal/extractor/extractor_test.go
+++ b/go/internal/extractor/extractor_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pymupdf4llm-c/go/internal/bridge"
-	"github.com/pymupdf4llm-c/go/internal/models"
-	"github.com/pymupdf4llm-c/go/internal/testutil"
+	"github.com/fibrumpdf/go/internal/bridge"
+	"github.com/fibrumpdf/go/internal/models"
+	"github.com/fibrumpdf/go/internal/testutil"
 )
 
 func extractTestPDF(t *testing.T, pdfName string) []models.Page {

--- a/go/internal/logger/logger.go
+++ b/go/internal/logger/logger.go
@@ -26,7 +26,7 @@ const (
 func init() {
 	var fileHandler *customHandler
 
-	logPath := filepath.Join(tempDir, "pymupdf4llm_c.log")
+	logPath := filepath.Join(tempDir, "fibrumpdf.log")
 	
 	fmt.Printf("writing all logs to: %s\n", logPath)
 

--- a/go/internal/models/models.go
+++ b/go/internal/models/models.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/pymupdf4llm-c/go/internal/geometry"
+	"github.com/fibrumpdf/go/internal/geometry"
 )
 
 type BBox [4]float32

--- a/go/internal/table/table.go
+++ b/go/internal/table/table.go
@@ -5,10 +5,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pymupdf4llm-c/go/internal/bridge"
-	"github.com/pymupdf4llm-c/go/internal/geometry"
-	"github.com/pymupdf4llm-c/go/internal/logger"
-	"github.com/pymupdf4llm-c/go/internal/models"
+	"github.com/fibrumpdf/go/internal/bridge"
+	"github.com/fibrumpdf/go/internal/geometry"
+	"github.com/fibrumpdf/go/internal/logger"
+	"github.com/fibrumpdf/go/internal/models"
 	"github.com/tidwall/rtree"
 )
 

--- a/go/internal/table/table_test.go
+++ b/go/internal/table/table_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pymupdf4llm-c/go/internal/bridge"
-	"github.com/pymupdf4llm-c/go/internal/geometry"
-	"github.com/pymupdf4llm-c/go/internal/testutil"
+	"github.com/fibrumpdf/go/internal/bridge"
+	"github.com/fibrumpdf/go/internal/geometry"
+	"github.com/fibrumpdf/go/internal/testutil"
 )
 
 func loadTestPDFPages(t *testing.T, pdfName string) []*bridge.RawPageData {


### PR DESCRIPTION
- make `github.com/intercepted16/pymupdf4llm-c` -> `github.com/intercepted16/fibrumpdf` in Go package and imports
- rename log file from `pymupdf4llm_c.log` -> `fibrumpdf.log`