### PR TITLE
chore: bump Go to 1.24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
           cache-dependency-path: go/go.sum
 
       - name: Install uv

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/fibrumpdf/go
 
-go 1.21
+go 1.24
 
 require github.com/tidwall/rtree v1.10.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ build = [
 environment = { LD_LIBRARY_PATH = "$PWD/lib/mupdf:$LD_LIBRARY_PATH", PATH = "/usr/local/go/bin:$PATH" }
 before-all = [
     "yum install -y wget tar || (apt-get update && apt-get install -y wget)",
-    "wget -q https://go.dev/dl/go1.21.0.linux-amd64.tar.gz",
-    "tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz",
+    "wget -q https://go.dev/dl/go1.24.0.linux-amd64.tar.gz",
+    "tar -C /usr/local -xzf go1.24.0.linux-amd64.tar.gz",
     "/usr/local/go/bin/go version",
     "mkdir -p lib/mupdf",
     "curl -L -o lib/mupdf/libmupdf.so https://github.com/intercepted16/mupdf-prebuilts/releases/download/mupdf-1.27.0/libmupdf.so",
@@ -58,7 +58,7 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} --plat manylinux_2_28_x8
 [tool.cibuildwheel.macos]
 environment = { DYLD_LIBRARY_PATH = "$PWD/lib/mupdf:$DYLD_LIBRARY_PATH" }
 before-all = [
-    "which go || brew install go@1.21 || true",
+    "which go || brew install go@1.24 || true",
     "go version",
     "mkdir -p lib/mupdf",
     "curl -L -o lib/mupdf/libmupdf.dylib https://github.com/intercepted16/mupdf-prebuilts/releases/download/mupdf-1.27.0/libmupdf.dylib",


### PR DESCRIPTION
* update `go.mod` with 1.24
* make `cibuildwheel` download 1.24.0
* GitHub action download 1.24.0