### PR TITLE
perf(go): optimize thoroughput of extractor (separate io/cpu, microoptimizations)

### DIFF
--- a/go/cmd/tojson/main.go
+++ b/go/cmd/tojson/main.go
@@ -5,6 +5,8 @@ package main
 */
 import "C"
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -15,14 +17,21 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
-	"github.com/fibrumpdf/go/internal/bridge"
 	"github.com/fibrumpdf/go/internal/extractor"
 	"github.com/fibrumpdf/go/internal/logger"
+	rawdata "github.com/fibrumpdf/go/internal/raw"
 )
 
 var Logger = logger.GetLogger("tomd")
+
+var bufferPool = sync.Pool{
+	New: func() any {
+		b := new(bytes.Buffer)
+		b.Grow(4096)
+		return b
+	},
+}
 
 //export pdf_to_json
 func pdf_to_json(pdf_path *C.char, output_file *C.char) C.int {
@@ -34,17 +43,18 @@ func pdf_to_json(pdf_path *C.char, output_file *C.char) C.int {
 	return -1
 }
 
-func processPage(pageFile string) ([]byte, error) {
-	rawData, err := bridge.ReadRawPage(pageFile)
-	if err != nil {
-		return nil, err
-	}
+func readRawPageData(pageFile string) (*rawdata.PageData, error) {
+	return rawdata.ReadRawPage(pageFile)
+}
+
+func processRawPage(rawData *rawdata.PageData, buf *bytes.Buffer) error {
 	page := extractor.ExtractPageFromRaw(rawData)
-	pageJSON, err := json.Marshal(page)
-	if err != nil {
-		return nil, err
+	buf.Reset()
+	encoder := json.NewEncoder(buf)
+	if err := encoder.Encode(page); err != nil {
+		return err
 	}
-	return pageJSON, nil
+	return nil
 }
 
 func pdfToJson(pdfPath, outputPath string) error {
@@ -91,13 +101,70 @@ func pdfToJson(pdfPath, outputPath string) error {
 		results = make([]pageResult, len(pageFiles))
 		for i, pageFile := range pageFiles {
 			pageNum := extractPageNum(pageFile)
-			pageJSON, err := processPage(pageFile)
-			results[i] = pageResult{pageNum: pageNum, json: pageJSON, err: err}
+			rawData, err := readRawPageData(pageFile)
+			if err != nil {
+				Logger.Error("processing error", "err", err)
+				return err
+			}
+			buf := bufferPool.Get().(*bytes.Buffer)
+			buf.Reset()
+			err = processRawPage(rawData, buf)
+			if err != nil {
+				bufferPool.Put(buf)
+				Logger.Error("processing error", "err", err)
+				return err
+			}
+			result := buf.Bytes()
+			if len(result) > 0 && result[len(result)-1] == '\n' {
+				result = result[:len(result)-1]
+			}
+			pageJSON := append([]byte(nil), result...)
+			buf.Reset()
+			bufferPool.Put(buf)
+			if err := writePage(pageJSON, pageNum); err != nil {
+				Logger.Error("write error", "err", err)
+				return err
+			}
 		}
 	} else {
 		var wg sync.WaitGroup
 		pageChan := make(chan int, numWorkers)
-		results = make([]pageResult, len(pageFiles))
+		resultChan := make(chan pageResult, numWorkers)
+
+		for i := 0; i < numWorkers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for idx := range pageChan {
+					pageFile := pageFiles[idx]
+					pageNum := extractPageNum(pageFile)
+					rawData, err := readRawPageData(pageFile)
+					if err != nil {
+						resultChan <- pageResult{idx: idx, pageNum: pageNum, json: nil, err: err}
+						Logger.Debug("processed page", "page", pageNum, "err", err)
+						continue
+					}
+					buf := bufferPool.Get().(*bytes.Buffer)
+					buf.Reset()
+					err = processRawPage(rawData, buf)
+					if err != nil {
+						bufferPool.Put(buf)
+						resultChan <- pageResult{idx: idx, pageNum: pageNum, json: nil, err: err}
+						Logger.Debug("processed page", "page", pageNum, "err", err)
+						continue
+					}
+					result := buf.Bytes()
+					if len(result) > 0 && result[len(result)-1] == '\n' {
+						result = result[:len(result)-1]
+					}
+					output := append([]byte(nil), result...)
+					buf.Reset()
+					bufferPool.Put(buf)
+					resultChan <- pageResult{idx: idx, pageNum: pageNum, json: output, err: nil}
+					Logger.Debug("processed page", "page", pageNum)
+				}
+			}()
+		}
 
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)

--- a/go/cmd/tojson/main.go
+++ b/go/cmd/tojson/main.go
@@ -8,19 +8,22 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
+	rawdata "github.com/fibrumpdf/go/internal/bridge"
 	"github.com/fibrumpdf/go/internal/extractor"
 	"github.com/fibrumpdf/go/internal/logger"
-	rawdata "github.com/fibrumpdf/go/internal/raw"
 )
 
 var Logger = logger.GetLogger("tomd")
@@ -43,11 +46,11 @@ func pdf_to_json(pdf_path *C.char, output_file *C.char) C.int {
 	return -1
 }
 
-func readRawPageData(pageFile string) (*rawdata.PageData, error) {
+func readRawPageData(pageFile string) (*rawdata.RawPageData, error) {
 	return rawdata.ReadRawPage(pageFile)
 }
 
-func processRawPage(rawData *rawdata.PageData, buf *bytes.Buffer) error {
+func processRawPage(rawData *rawdata.RawPageData, buf *bytes.Buffer) error {
 	page := extractor.ExtractPageFromRaw(rawData)
 	buf.Reset()
 	encoder := json.NewEncoder(buf)
@@ -64,7 +67,7 @@ func pdfToJson(pdfPath, outputPath string) error {
 	Logger.Info("beginning conversion...")
 	Logger.Debug("paths", "pdf", pdfPath, "output", outputPath)
 
-	tempRawDir, err := bridge.ExtractAllPagesRaw(pdfPath)
+	tempRawDir, err := rawdata.ExtractAllPagesRaw(pdfPath)
 	rawElapsed := time.Since(startRaw)
 	if err != nil {
 		Logger.Error("extraction error", "err", err)
@@ -89,128 +92,159 @@ func pdfToJson(pdfPath, outputPath string) error {
 		pageNum int
 		json    []byte
 		err     error
+		idx     int
 	}
-	var results []pageResult
-	numWorkers := runtime.NumCPU()
-	threshold := 10
-	if numWorkers*2 > threshold {
-		threshold = numWorkers * 2
+
+	type rawPageData struct {
+		idx     int
+		pageNum int
+		data    *rawdata.RawPageData
+		err     error
 	}
-	if len(pageFiles) < threshold {
-		// sequential
-		results = make([]pageResult, len(pageFiles))
-		for i, pageFile := range pageFiles {
-			pageNum := extractPageNum(pageFile)
-			rawData, err := readRawPageData(pageFile)
-			if err != nil {
-				Logger.Error("processing error", "err", err)
-				return err
-			}
-			buf := bufferPool.Get().(*bytes.Buffer)
-			buf.Reset()
-			err = processRawPage(rawData, buf)
-			if err != nil {
-				bufferPool.Put(buf)
-				Logger.Error("processing error", "err", err)
-				return err
-			}
-			result := buf.Bytes()
-			if len(result) > 0 && result[len(result)-1] == '\n' {
-				result = result[:len(result)-1]
-			}
-			pageJSON := append([]byte(nil), result...)
-			buf.Reset()
-			bufferPool.Put(buf)
-			if err := writePage(pageJSON, pageNum); err != nil {
-				Logger.Error("write error", "err", err)
-				return err
-			}
-		}
-	} else {
-		var wg sync.WaitGroup
-		pageChan := make(chan int, numWorkers)
-		resultChan := make(chan pageResult, numWorkers)
 
-		for i := 0; i < numWorkers; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for idx := range pageChan {
-					pageFile := pageFiles[idx]
-					pageNum := extractPageNum(pageFile)
-					rawData, err := readRawPageData(pageFile)
-					if err != nil {
-						resultChan <- pageResult{idx: idx, pageNum: pageNum, json: nil, err: err}
-						Logger.Debug("processed page", "page", pageNum, "err", err)
-						continue
-					}
-					buf := bufferPool.Get().(*bytes.Buffer)
-					buf.Reset()
-					err = processRawPage(rawData, buf)
-					if err != nil {
-						bufferPool.Put(buf)
-						resultChan <- pageResult{idx: idx, pageNum: pageNum, json: nil, err: err}
-						Logger.Debug("processed page", "page", pageNum, "err", err)
-						continue
-					}
-					result := buf.Bytes()
-					if len(result) > 0 && result[len(result)-1] == '\n' {
-						result = result[:len(result)-1]
-					}
-					output := append([]byte(nil), result...)
-					buf.Reset()
-					bufferPool.Put(buf)
-					resultChan <- pageResult{idx: idx, pageNum: pageNum, json: output, err: nil}
-					Logger.Debug("processed page", "page", pageNum)
-				}
-			}()
-		}
+	numCores := runtime.NumCPU()
+	ioWorkers := min(numCores*2, len(pageFiles))
+	numWorkers := min(numCores*3, len(pageFiles))
 
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
+	pageChan := make(chan int, len(pageFiles))
+	rawChan := make(chan rawPageData, len(pageFiles))
+	resultChan := make(chan pageResult, numWorkers*4)
+
+	ioWg := sync.WaitGroup{}
+	for range ioWorkers {
+		ioWg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer ioWg.Done()
 			for idx := range pageChan {
 				pageFile := pageFiles[idx]
 				pageNum := extractPageNum(pageFile)
-				pageJSON, err := processPage(pageFile)
-				results[idx] = pageResult{pageNum: pageNum, json: pageJSON, err: err}
-				Logger.Debug("processed page", "page", pageNum, "err", err)
+				rawData, err := readRawPageData(pageFile)
+				rawChan <- rawPageData{idx: idx, pageNum: pageNum, data: rawData, err: err}
+				Logger.Debug("read raw page", "page", pageNum, "err", err)
 			}
 		}()
 	}
 
-	for i := range pageFiles {
-		pageChan <- i
+	go func() {
+		ioWg.Wait()
+		close(rawChan)
+	}()
+
+	cpuWg := sync.WaitGroup{}
+	for range numWorkers {
+		cpuWg.Add(1)
+		go func() {
+			defer cpuWg.Done()
+			for raw := range rawChan {
+				if raw.err != nil {
+					resultChan <- pageResult{idx: raw.idx, pageNum: raw.pageNum, json: nil, err: raw.err}
+					continue
+				}
+
+				buf := bufferPool.Get().(*bytes.Buffer)
+				buf.Reset()
+
+				err := processRawPage(raw.data, buf)
+				if err != nil {
+					bufferPool.Put(buf)
+					resultChan <- pageResult{idx: raw.idx, pageNum: raw.pageNum, json: nil, err: err}
+					continue
+				}
+
+				result := buf.Bytes()
+				if len(result) > 0 && result[len(result)-1] == '\n' {
+					result = result[:len(result)-1]
+				}
+				output := append([]byte(nil), result...)
+
+				buf.Reset()
+				bufferPool.Put(buf)
+
+				resultChan <- pageResult{idx: raw.idx, pageNum: raw.pageNum, json: output, err: nil}
+				Logger.Debug("processed page", "page", raw.pageNum)
+			}
+		}()
 	}
-	close(pageChan)
-	wg.Wait()
 
-}
+	go func() {
+		cpuWg.Wait()
+		close(resultChan)
+	}()
 
-	for _, res := range results {
-		if res.err != nil {
-			Logger.Error("processing error", "err", res.err)
-			return res.err
+	go func() {
+		for i := range pageFiles {
+			pageChan <- i
 		}
-	}
+		close(pageChan)
+	}()
 
-	outFile, err := os.Create(outputPath)
+	outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		Logger.Error("output file error", "err", err)
 		return err
 	}
-	defer outFile.Close()
+	defer outputFile.Close()
 
-	pageList := make([]json.RawMessage, len(results))
-	for i, res := range results {
-		pageList[i] = json.RawMessage(res.json)
-		Logger.Debug("wrote page", "page", res.pageNum)
+	writer := bufio.NewWriterSize(outputFile, 1<<20)
+	if _, err := writer.WriteString("["); err != nil {
+		Logger.Error("write error", "err", err)
+		return err
 	}
 
-	encoder := json.NewEncoder(outFile)
-	if err := encoder.Encode(pageList); err != nil {
+	wroteAny := false
+	writePage := func(pageJSON []byte, pageNum int) error {
+		if wroteAny {
+			if _, err := writer.WriteString(","); err != nil {
+				return err
+			}
+		}
+		if _, err := writer.Write(pageJSON); err != nil {
+			return err
+		}
+		wroteAny = true
+		Logger.Debug("wrote page", "page", pageNum)
+		return nil
+	}
+
+	pending := make(map[int]pageResult, len(pageFiles))
+
+	nextIdx := 0
+	var firstErr error
+	for res := range resultChan {
+		if res.err != nil && firstErr == nil {
+			firstErr = res.err
+			Logger.Error("processing error", "err", res.err)
+		}
+		pending[res.idx] = res
+		for {
+			nextRes, ok := pending[nextIdx]
+			if !ok {
+				break
+			}
+			if firstErr == nil {
+				if err := writePage(nextRes.json, nextRes.pageNum); err != nil {
+					firstErr = err
+					Logger.Error("write error", "err", err)
+				}
+			}
+			delete(pending, nextIdx)
+			nextIdx++
+		}
+	}
+	if firstErr != nil {
+		return firstErr
+	}
+
+	if _, err := writer.WriteString("]\n"); err != nil {
 		Logger.Error("write error", "err", err)
+		return err
+	}
+	if err := writer.Flush(); err != nil {
+		Logger.Error("write error", "err", err)
+		return err
+	}
+	if err := outputFile.Close(); err != nil {
+		Logger.Error("output file error", "err", err)
 		return err
 	}
 
@@ -236,9 +270,44 @@ func extractPageNum(filename string) int {
 }
 
 func main() {
-	if len(os.Args) < 3 {
-		fmt.Println("Usage: ./tojson <input.pdf> [output_json]")
+	cpuprofile := flag.String("cpuprofile", "", "write cpu profile to file")
+
+	memprofile := flag.String("memprofile", "", "write memory profile to file")
+	flag.Parse()
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not create CPU profile: %v\n", err)
+			os.Exit(1)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
+	args := flag.Args()
+	if len(args) < 2 {
+		fmt.Println("Usage: ./tojson <input.pdf> <output_json>")
 		os.Exit(1)
 	}
-	pdfToJson(os.Args[1], os.Args[2])
+
+	err := pdfToJson(args[0], args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *memprofile != "" {
+		f, err := os.Create(*memprofile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not create memory profile: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			fmt.Fprintf(os.Stderr, "Could not write memory profile: %v\n", err)
+			os.Exit(1)
+		}
+	}
 }

--- a/go/internal/bridge/bridge.c
+++ b/go/internal/bridge/bridge.c
@@ -3,12 +3,12 @@
 // (approx. 3x slower overall)
 // so, use one function that writes to disk instead, much less overhead.
 // this is mostly pre existing logic just written to be used via Go.
-// additionally, the raw 'binary' format is used for performance and less disk usage. json gets very taxing on thousands
-// of chars.
+// additionally, the raw 'binary' format is used for performance and less disk usage. json gets very taxing on thousands of chars.
 
 #include "bridge.h"
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
@@ -17,20 +17,23 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <pthread.h>
+#include <math.h>
 
 #define EDGE_MIN_LENGTH 3.0
 #define EDGE_MAX_WIDTH 3.0
 #define FZ_STORE_SIZE 256 * 1024 * 1024
-
-    typedef struct
-{
-    fz_device super;
-    fz_device* stext_dev;
-    edge_array* edges;
-} combined_device;
+#define MIN_EDGE_LENGTH 6.0
+#define EDGE_DUP_TOL 0.35
+#define MAX_DUP_CHECK 48
 
 typedef struct
 {
+    fz_device super;
+    fz_device* stext_dev;  
+    edge_array* edges;
+} combined_device;
+
+typedef struct {
     fz_font* font;
     unsigned char flags;
 } font_cache_entry;
@@ -39,28 +42,59 @@ typedef struct
    Uses process-shared mutex to synchronize access between workers.
    Persists across all pages and all workers to maximize cache reuse. */
 #define FONT_CACHE_SIZE 256
-typedef struct
-{
+typedef struct {
     pthread_mutex_t lock;
     font_cache_entry entries[FONT_CACHE_SIZE];
     int len;
 } shared_font_cache;
 
 static shared_font_cache* global_font_cache = NULL;
-static font_cache_entry local_font_cache[FONT_CACHE_SIZE];
-static int local_font_cache_len = 0;
-static int use_shared_font_cache = 0;
 
-static void reset_local_font_cache(void)
-{
-    local_font_cache_len = 0;
+static int contains_token_ci(const char* haystack, const char* needle) {
+    if (!haystack || !needle || !needle[0])
+        return 0;
+    size_t hlen = strlen(haystack);
+    size_t nlen = strlen(needle);
+    if (nlen > hlen)
+        return 0;
+    for (size_t i = 0; i <= hlen - nlen; i++) {
+        size_t j = 0;
+        while (j < nlen) {
+            unsigned char hc = (unsigned char)haystack[i + j];
+            unsigned char nc = (unsigned char)needle[j];
+            if (tolower(hc) != tolower(nc))
+                break;
+            j++;
+        }
+        if (j == nlen)
+            return 1;
+    }
+    return 0;
+}
+
+static unsigned char infer_style_from_font_name(const char* name) {
+    if (!name || !name[0])
+        return 0;
+
+    unsigned char flags = 0;
+    if (contains_token_ci(name, "bold") || contains_token_ci(name, "black") ||
+        contains_token_ci(name, "heavy") || contains_token_ci(name, "semibold") ||
+        contains_token_ci(name, "demi")) {
+        flags |= 1;
+    }
+    if (contains_token_ci(name, "italic") || contains_token_ci(name, "oblique") ||
+        contains_token_ci(name, "kursiv") || contains_token_ci(name, "slanted")) {
+        flags |= 2;
+    }
+    return flags;
 }
 
 /* Initialize shared font cache (call in parent before fork) */
-static int init_shared_font_cache(void)
-{
-    global_font_cache =
-        mmap(NULL, sizeof(shared_font_cache), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+static int init_shared_font_cache(void) {
+    global_font_cache = mmap(NULL, sizeof(shared_font_cache), 
+                             PROT_READ | PROT_WRITE, 
+                             MAP_SHARED | MAP_ANONYMOUS, 
+                             -1, 0);
     if (global_font_cache == MAP_FAILED)
         return -1;
 
@@ -69,9 +103,8 @@ static int init_shared_font_cache(void)
     pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
     int ret = pthread_mutex_init(&global_font_cache->lock, &attr);
     pthread_mutexattr_destroy(&attr);
-
-    if (ret != 0)
-    {
+    
+    if (ret != 0) {
         munmap(global_font_cache, sizeof(shared_font_cache));
         global_font_cache = NULL;
         return -1;
@@ -82,8 +115,7 @@ static int init_shared_font_cache(void)
 }
 
 /* Cleanup shared font cache (call after all workers finish) */
-static void cleanup_shared_font_cache(void)
-{
+static void cleanup_shared_font_cache(void) {
     if (!global_font_cache)
         return;
     pthread_mutex_destroy(&global_font_cache->lock);
@@ -92,89 +124,45 @@ static void cleanup_shared_font_cache(void)
 }
 
 /* Lookup or add font to shared cache. Returns flags for the font. */
-static unsigned char get_font_flags(fz_context* ctx, fz_font* f)
-{
-    if (!f)
+static unsigned char get_font_flags(fz_context* ctx, fz_font* f) {
+    if (!f || !global_font_cache)
         return 0;
 
-    if (use_shared_font_cache && global_font_cache)
-    {
-        pthread_mutex_lock(&global_font_cache->lock);
+    pthread_mutex_lock(&global_font_cache->lock);
 
-        for (int i = 0; i < global_font_cache->len; i++)
-        {
-            if (global_font_cache->entries[i].font == f)
-            {
-                unsigned char flags = global_font_cache->entries[i].flags;
-                pthread_mutex_unlock(&global_font_cache->lock);
-                return flags;
-            }
+    for (int i = 0; i < global_font_cache->len; i++) {
+        if (global_font_cache->entries[i].font == f) {
+            unsigned char flags = global_font_cache->entries[i].flags;
+            pthread_mutex_unlock(&global_font_cache->lock);
+            return flags;
         }
-
-        unsigned char flags = 0;
-        if (fz_font_is_bold(ctx, f))
-            flags |= 1;
-        if (fz_font_is_italic(ctx, f))
-            flags |= 2;
-        if (fz_font_is_monospaced(ctx, f))
-            flags |= 4;
-
-        if (global_font_cache->len < FONT_CACHE_SIZE)
-        {
-            global_font_cache->entries[global_font_cache->len].font = f;
-            global_font_cache->entries[global_font_cache->len].flags = flags;
-            global_font_cache->len++;
-        }
-
-        pthread_mutex_unlock(&global_font_cache->lock);
-        return flags;
-    }
-
-    for (int i = 0; i < local_font_cache_len; i++)
-    {
-        if (local_font_cache[i].font == f)
-            return local_font_cache[i].flags;
     }
 
     unsigned char flags = 0;
-    if (fz_font_is_bold(ctx, f))
-        flags |= 1;
-    if (fz_font_is_italic(ctx, f))
-        flags |= 2;
-    if (fz_font_is_monospaced(ctx, f))
-        flags |= 4;
+    fz_font_flags_t* ff = fz_font_flags(f);
+    if (fz_font_is_bold(ctx, f)) flags |= 1;
+    if (fz_font_is_italic(ctx, f)) flags |= 2;
+    if (fz_font_is_monospaced(ctx, f)) flags |= 4;
+    if (ff && ff->fake_bold) flags |= 1;
+    if (ff && ff->fake_italic) flags |= 2;
+    flags |= infer_style_from_font_name(fz_font_name(ctx, f));
 
-    if (local_font_cache_len < FONT_CACHE_SIZE)
-    {
-        local_font_cache[local_font_cache_len].font = f;
-        local_font_cache[local_font_cache_len].flags = flags;
-        local_font_cache_len++;
+    if (global_font_cache->len < FONT_CACHE_SIZE) {
+        global_font_cache->entries[global_font_cache->len].font = f;
+        global_font_cache->entries[global_font_cache->len].flags = flags;
+        global_font_cache->len++;
     }
 
+    pthread_mutex_unlock(&global_font_cache->lock);
     return flags;
 }
 
-static int should_skip_images(void)
-{
-    static int init = 0;
-    static int skip = 0;
-    if (!init)
-    {
-        const char* v = getenv("PYMUPDF_SKIP_IMAGES");
-        skip = (v && v[0] != '\0' && v[0] != '0') ? 1 : 0;
-        init = 1;
-    }
-    return skip;
-}
-
-static void mupdf_warning_callback(void* user, const char* message)
-{
+static void mupdf_warning_callback(void* user, const char* message) {
     (void)user;
     (void)message;
 }
 
-static void mupdf_error_callback(void* user, const char* message)
-{
+static void mupdf_error_callback(void* user, const char* message) {
     (void)user;
     (void)message;
 }
@@ -241,8 +229,8 @@ static void combined_stroke_path(fz_context* ctx, fz_device* dev, const fz_path*
         cdev->stext_dev->stroke_path(ctx, cdev->stext_dev, path, stroke, ctm, cs, color, alpha, cp);
 }
 
-static void combined_fill_text(fz_context* ctx, fz_device* dev, const fz_text* text, fz_matrix ctm, fz_colorspace* cs,
-                               const float* color, float alpha, fz_color_params cp)
+static void combined_fill_text(fz_context* ctx, fz_device* dev, const fz_text* text, fz_matrix ctm,
+                               fz_colorspace* cs, const float* color, float alpha, fz_color_params cp)
 {
     combined_device* cdev = (combined_device*)dev;
     if (cdev->stext_dev && cdev->stext_dev->fill_text)
@@ -264,8 +252,8 @@ static void combined_clip_text(fz_context* ctx, fz_device* dev, const fz_text* t
         cdev->stext_dev->clip_text(ctx, cdev->stext_dev, text, ctm, scissor);
 }
 
-static void combined_clip_stroke_text(fz_context* ctx, fz_device* dev, const fz_text* text,
-                                      const fz_stroke_state* stroke, fz_matrix ctm, fz_rect scissor)
+static void combined_clip_stroke_text(fz_context* ctx, fz_device* dev, const fz_text* text, const fz_stroke_state* stroke,
+                                      fz_matrix ctm, fz_rect scissor)
 {
     combined_device* cdev = (combined_device*)dev;
     if (cdev->stext_dev && cdev->stext_dev->clip_stroke_text)
@@ -279,32 +267,37 @@ static void combined_ignore_text(fz_context* ctx, fz_device* dev, const fz_text*
         cdev->stext_dev->ignore_text(ctx, cdev->stext_dev, text, ctm);
 }
 
-static void combined_fill_shade(fz_context* ctx, fz_device* dev, fz_shade* shd, fz_matrix ctm, float alpha,
-                                fz_color_params cp)
+static void combined_fill_shade(fz_context* ctx, fz_device* dev, fz_shade* shd, fz_matrix ctm, float alpha, fz_color_params cp)
 {
-    combined_device* cdev = (combined_device*)dev;
-    if (cdev->stext_dev && cdev->stext_dev->fill_shade)
-        cdev->stext_dev->fill_shade(ctx, cdev->stext_dev, shd, ctm, alpha, cp);
+    (void)ctx;
+    (void)dev;
+    (void)shd;
+    (void)ctm;
+    (void)alpha;
+    (void)cp;
 }
 
-static void combined_fill_image(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm, float alpha,
-                                fz_color_params cp)
+static void combined_fill_image(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm, float alpha, fz_color_params cp)
 {
-    combined_device* cdev = (combined_device*)dev;
-    if (should_skip_images())
-        return;
-    if (cdev->stext_dev && cdev->stext_dev->fill_image)
-        cdev->stext_dev->fill_image(ctx, cdev->stext_dev, img, ctm, alpha, cp);
+    (void)ctx;
+    (void)dev;
+    (void)img;
+    (void)ctm;
+    (void)alpha;
+    (void)cp;
 }
 
-static void combined_fill_image_mask(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm, fz_colorspace* cs,
-                                     const float* color, float alpha, fz_color_params cp)
+static void combined_fill_image_mask(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm,
+                                     fz_colorspace* cs, const float* color, float alpha, fz_color_params cp)
 {
-    combined_device* cdev = (combined_device*)dev;
-    if (should_skip_images())
-        return;
-    if (cdev->stext_dev && cdev->stext_dev->fill_image_mask)
-        cdev->stext_dev->fill_image_mask(ctx, cdev->stext_dev, img, ctm, cs, color, alpha, cp);
+    (void)ctx;
+    (void)dev;
+    (void)img;
+    (void)ctm;
+    (void)cs;
+    (void)color;
+    (void)alpha;
+    (void)cp;
 }
 
 static void combined_begin_metatext(fz_context* ctx, fz_device* dev, fz_metatext meta, const char* text)
@@ -345,47 +338,192 @@ static void free_edge_array(edge_array* edges)
     edges->capacity = 0;
 }
 
+static double edge_length(const edge* e)
+{
+    if (!e)
+        return 0.0;
+    if (e->orientation == 'h')
+        return fabs(e->x1 - e->x0);
+    return fabs(e->y1 - e->y0);
+}
+
+static int edges_similar(const edge* a, const edge* b)
+{
+    if (!a || !b)
+        return 0;
+    if (a->orientation != b->orientation)
+        return 0;
+    double tol = EDGE_DUP_TOL;
+    if (fabs(a->x0 - b->x0) > tol || fabs(a->y0 - b->y0) > tol)
+        return 0;
+    if (fabs(a->x1 - b->x1) > tol || fabs(a->y1 - b->y1) > tol)
+        return 0;
+    return 1;
+}
+
+static void filter_edges(edge_array* arr)
+{
+    if (!arr || arr->count <= 0)
+        return;
+    edge* old = arr->items;
+    int old_count = arr->count;
+    edge* filtered = malloc(old_count * sizeof(edge));
+    if (!filtered)
+        return;
+    int keep = 0;
+    for (int i = 0; i < old_count; i++) {
+        edge* current = &old[i];
+        if (edge_length(current) < MIN_EDGE_LENGTH)
+            continue;
+        int dup = 0;
+        int limit = MAX_DUP_CHECK;
+        for (int j = keep - 1; j >= 0 && limit > 0; j--, limit--) {
+            if (edges_similar(&filtered[j], current)) {
+                dup = 1;
+                break;
+            }
+        }
+        if (dup)
+            continue;
+        filtered[keep++] = *current;
+    }
+    free(old);
+    arr->items = filtered;
+    arr->count = keep;
+    arr->capacity = keep;
+}
+
+static int is_ascii_letter(int c)
+{
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
+static int is_italic_shear_candidate(const fz_stext_char* ch)
+{
+    if (!ch)
+        return 0;
+
+    float left_h = ch->quad.ul.y - ch->quad.ll.y;
+    float right_h = ch->quad.ur.y - ch->quad.lr.y;
+    if (left_h < 0) left_h = -left_h;
+    if (right_h < 0) right_h = -right_h;
+    float h = (left_h + right_h) * 0.5f;
+    if (h < 1e-3f)
+        return 0;
+
+    float left_dx = (ch->quad.ul.x - ch->quad.ll.x) / h;
+    float right_dx = (ch->quad.ur.x - ch->quad.lr.x) / h;
+
+    if ((left_dx > 0 && right_dx < 0) || (left_dx < 0 && right_dx > 0))
+        return 0;
+
+    float shear = (left_dx + right_dx) * 0.5f;
+    if (shear < 0) shear = -shear;
+
+    return shear >= 0.24f && shear <= 0.55f;
+}
+
 static void write_all_char_data(FILE* out, fz_context* ctx, fz_stext_page* stext, int expected_total)
 {
     int written = 0;
+    fchar* line_buffer = NULL;
+    size_t line_buffer_capacity = 0;
+    uint8_t* italic_candidate = NULL;
+    size_t italic_capacity = 0;
+
     for (fz_stext_block* block = stext->first_block; block; block = block->next)
     {
         if (block->type != FZ_STEXT_BLOCK_TEXT)
             continue;
         for (fz_stext_line* line = block->u.t.first_line; line; line = line->next)
         {
+            int line_chars = 0;
             for (fz_stext_char* ch = line->first_char; ch; ch = ch->next)
             {
+                size_t required = (size_t)line_chars + 1;
+                if (required > line_buffer_capacity)
+                {
+                    size_t new_capacity = line_buffer_capacity ? line_buffer_capacity * 2 : 256;
+                    while (new_capacity < required)
+                        new_capacity *= 2;
+                    fchar* resized = realloc(line_buffer, new_capacity * sizeof(fchar));
+                    if (!resized)
+                        break;
+                    line_buffer = resized;
+                    line_buffer_capacity = new_capacity;
+                }
+                if (required > italic_capacity)
+                {
+                    size_t new_capacity = italic_capacity ? italic_capacity * 2 : 256;
+                    while (new_capacity < required)
+                        new_capacity *= 2;
+                    uint8_t* resized = realloc(italic_candidate, new_capacity * sizeof(uint8_t));
+                    if (!resized)
+                        break;
+                    italic_candidate = resized;
+                    italic_capacity = new_capacity;
+                }
+
                 fchar rc = {0};
                 rc.codepoint = ch->c;
                 rc.size = ch->size;
 
-                // Determine bbox from the character's quad
                 float x0 = ch->quad.ll.x;
                 float y0 = ch->quad.ll.y;
                 float x1 = ch->quad.ur.x;
                 float y1 = ch->quad.ur.y;
-                // Ensure proper min/max ordering
                 rc.bbox_x0 = x0 < x1 ? x0 : x1;
                 rc.bbox_y0 = y0 < y1 ? y0 : y1;
                 rc.bbox_x1 = x0 > x1 ? x0 : x1;
                 rc.bbox_y1 = y0 > y1 ? y0 : y1;
 
                 unsigned char flags = get_font_flags(ctx, ch->font);
-                rc.is_bold = (flags & 1) ? 1 : 0;
+                rc.is_bold = (flags & 1) || (ch->flags & FZ_STEXT_BOLD) ? 1 : 0;
                 rc.is_italic = (flags & 2) ? 1 : 0;
                 rc.is_monospaced = (flags & 4) ? 1 : 0;
 
-                fwrite(&rc, sizeof(fchar), 1, out);
-                written++;
+                line_buffer[line_chars] = rc;
+                italic_candidate[line_chars] = (rc.is_italic == 0 && is_italic_shear_candidate(ch)) ? 1 : 0;
+                line_chars++;
             }
+            if (line_chars == 0)
+                continue;
+
+            for (int i = 0; i < line_chars; )
+            {
+                if (!italic_candidate[i])
+                {
+                    i++;
+                    continue;
+                }
+                int start = i;
+                int run_len = 0;
+                int letter_count = 0;
+                while (i < line_chars && italic_candidate[i])
+                {
+                    if (is_ascii_letter(line_buffer[i].codepoint))
+                        letter_count++;
+                    run_len++;
+                    i++;
+                }
+                if (run_len >= 8 && letter_count >= 7)
+                {
+                    for (int j = start; j < i; j++)
+                        line_buffer[j].is_italic = 1;
+                }
+            }
+
+            fwrite(line_buffer, sizeof(fchar), (size_t)line_chars, out);
+            written += line_chars;
         }
     }
-    (void)expected_total; // could assert match
+
+    free(line_buffer);
+    free(italic_candidate);
+    (void)expected_total;
 }
 
-static int count_links(fz_link* links)
-{
+static int count_links(fz_link* links) {
     int count = 0;
     for (fz_link* l = links; l; l = l->next)
         count++;
@@ -461,8 +599,6 @@ static int extract_page_to_file(fz_context* ctx, fz_document* doc, int page_num,
 
         for (fz_stext_block* block = stext->first_block; block; block = block->next)
         {
-            if (block->type != FZ_STEXT_BLOCK_TEXT)
-                continue;
 
             if (total_blocks >= blocks_capacity)
             {
@@ -525,6 +661,7 @@ static int extract_page_to_file(fz_context* ctx, fz_document* doc, int page_num,
         }
 
         int page_number = page_num + 1;
+        filter_edges(&edges);
         fwrite(&page_number, sizeof(int), 1, out);
         fwrite(&bounds, sizeof(fz_rect), 1, out);
         fwrite(&total_blocks, sizeof(int), 1, out);
@@ -544,8 +681,7 @@ static int extract_page_to_file(fz_context* ctx, fz_document* doc, int page_num,
         if (edges.count > 0)
             fwrite(edges.items, sizeof(edge), edges.count, out);
 
-        for (fz_link* l = page_links; l; l = l->next)
-        {
+        for (fz_link* l = page_links; l; l = l->next) {
             fwrite(&l->rect, sizeof(fz_rect), 1, out);
             const char* uri = l->uri ? l->uri : "";
             int uri_len = strlen(uri);
@@ -556,6 +692,7 @@ static int extract_page_to_file(fz_context* ctx, fz_document* doc, int page_num,
 
         fclose(out);
         out = NULL;
+
     }
     fz_always(ctx)
     {
@@ -592,20 +729,14 @@ char* extract_all_pages(const char* pdf_path)
     snprintf(temp_dir, 256, ".pymupdfllm_c_%ld_%u", (long)time(NULL), (unsigned)getpid());
     mkdir(temp_dir, 0755);
 
-    use_shared_font_cache = 0;
-    global_font_cache = NULL;
-    reset_local_font_cache();
-
     fz_context* ctx = fz_new_context(NULL, NULL, FZ_STORE_SIZE);
-
-    if (!ctx)
-    {
-        cleanup_shared_font_cache();
-        free(temp_dir);
-        return NULL;
-    }
     fz_set_warning_callback(ctx, mupdf_warning_callback, NULL);
     fz_set_error_callback(ctx, mupdf_error_callback, NULL);
+
+    if (!ctx) {
+        cleanup_shared_font_cache();        free(temp_dir);
+        return NULL;
+    }
 
     fz_document* doc = NULL;
     int page_count = 0;
@@ -622,20 +753,17 @@ char* extract_all_pages(const char* pdf_path)
         error = 1;
     }
 
-    if (error || page_count == 0)
-    {
+    if (error || page_count == 0) {
         if (doc)
             fz_drop_document(ctx, doc);
         fz_drop_context(ctx);
-        cleanup_shared_font_cache();
-        free(temp_dir);
+        cleanup_shared_font_cache();        free(temp_dir);
         return NULL;
     }
 
     int num_workers = sysconf(_SC_NPROCESSORS_ONLN);
-    const char* workers_env = getenv("PYMUPDF_WORKERS");
-    if (workers_env && workers_env[0] != '\0')
-    {
+    const char *workers_env = getenv("PYMUPDF_WORKERS");
+    if (workers_env && workers_env[0] != '\0') {
         long w = strtol(workers_env, NULL, 10);
         if (w > 0)
             num_workers = (int)w;
@@ -643,38 +771,29 @@ char* extract_all_pages(const char* pdf_path)
     if (num_workers <= 0)
         num_workers = 4;
 
-    int threshold = (10 > num_workers * 2) ? 10 : num_workers * 2;
-    if (page_count < threshold)
-    {
-        num_workers = 1; /* force sequential */
+    if (num_workers > page_count)
+        num_workers = page_count;
+
+    int target_workers = (page_count + 2) / 3;
+    if (page_count >= 2 && target_workers < 2)
+        target_workers = 2;
+    if (target_workers > 0 && target_workers < num_workers)
+        num_workers = target_workers;
+    if (page_count < 64 && num_workers > 8)
+        num_workers = 8;
+
+    int threshold = 2;
+    if (page_count < threshold) {
+        num_workers = 1;  /* force sequential */
     }
 
-    if (num_workers > 1)
-    {
-        if (init_shared_font_cache() != 0)
-        {
-            if (doc)
-                fz_drop_document(ctx, doc);
-            fz_drop_context(ctx);
-            free(temp_dir);
-            return NULL;
-        }
-        use_shared_font_cache = 1;
-    }
-    else
-    {
-        use_shared_font_cache = 0;
-        reset_local_font_cache();
-    }
-
-    if (num_workers == 1)
-    {
-        for (int p = 0; p < page_count; p++)
-        {
+    if (num_workers == 1) {
+        for (int p = 0; p < page_count; p++) {
             char filename[512];
             snprintf(filename, sizeof(filename), "%s/page_%03d.raw", temp_dir, p + 1);
-            if (extract_page_to_file(ctx, doc, p, filename) != 0)
+            if (extract_page_to_file(ctx, doc, p, filename) != 0) {
                 fprintf(stderr, "Warning: failed to extract page %d\n", p + 1);
+            }
         }
 
         if (doc)
@@ -683,23 +802,26 @@ char* extract_all_pages(const char* pdf_path)
         return temp_dir;
     }
 
-    pid_t* pids = calloc(num_workers, sizeof(pid_t));
-    if (!pids)
-    {
+    if (init_shared_font_cache() != 0) {
         if (doc)
             fz_drop_document(ctx, doc);
         fz_drop_context(ctx);
-        if (use_shared_font_cache)
-            cleanup_shared_font_cache();
         free(temp_dir);
+        return NULL;
+    }
+
+    pid_t* pids = calloc(num_workers, sizeof(pid_t));
+    if (!pids) {
+        if (doc)
+            fz_drop_document(ctx, doc);
+        fz_drop_context(ctx);
+        cleanup_shared_font_cache();        free(temp_dir);
         return NULL;
     }
     int created = 0;
 
-    for (int i = 0; i < num_workers; i++)
-    {
-        int start = i;
-        if (start >= page_count)
+    for (int i = 0; i < num_workers; i++) {
+        int start = i;        if (start >= page_count)
             break;
 
         pid_t pid = fork();
@@ -708,8 +830,7 @@ char* extract_all_pages(const char* pdf_path)
             perror("fork");
             continue;
         }
-        if (pid == 0)
-        {
+        if (pid == 0) {
             /* CHILD: open its own context/document and process pages in round-robin */
             fz_context* child_ctx = fz_new_context(NULL, NULL, FZ_STORE_SIZE);
             if (!child_ctx)
@@ -718,13 +839,11 @@ char* extract_all_pages(const char* pdf_path)
             fz_set_error_callback(child_ctx, mupdf_error_callback, NULL);
 
             fz_document* child_doc = NULL;
-            fz_try(child_ctx)
-            {
+            fz_try(child_ctx) {
                 fz_register_document_handlers(child_ctx);
                 child_doc = fz_open_document(child_ctx, pdf_path);
             }
-            fz_catch(child_ctx)
-            {
+            fz_catch(child_ctx) {
                 if (child_doc)
                     fz_drop_document(child_ctx, child_doc);
                 fz_drop_context(child_ctx);
@@ -739,8 +858,7 @@ char* extract_all_pages(const char* pdf_path)
             if (child_do_profile)
                 clock_gettime(CLOCK_MONOTONIC, &child_t0);
 
-            for (int p = start; p < page_count; p += num_workers)
-            {
+            for (int p = start; p < page_count; p += num_workers) {
                 char filename[512];
                 snprintf(filename, sizeof(filename), "%s/page_%03d.raw", temp_dir, p + 1);
                 if (extract_page_to_file(child_ctx, child_doc, p, filename) != 0)
@@ -748,8 +866,7 @@ char* extract_all_pages(const char* pdf_path)
                 pages_processed++;
             }
 
-            if (child_do_profile)
-            {
+            if (child_do_profile) {
                 clock_gettime(CLOCK_MONOTONIC, &child_t1);
                 double sec = (child_t1.tv_sec - child_t0.tv_sec) + (child_t1.tv_nsec - child_t0.tv_nsec) * 1e-9;
                 fprintf(stderr, "CHILD PROFILE pid=%d pages=%d total=%.3f s\n", (int)getpid(), pages_processed, sec);
@@ -758,27 +875,24 @@ char* extract_all_pages(const char* pdf_path)
             if (child_doc)
                 fz_drop_document(child_ctx, child_doc);
             fz_drop_context(child_ctx);
-            _exit(0);
-        }
+            _exit(0);        }
         pids[created++] = pid;
     }
 
     /* Using round-robin forked workers; no pipe writes necessary. Parent simply waits for children. */
 
-    for (int i = 0; i < created; i++)
-    {
+    for (int i = 0; i < created; i++) {
         int wstatus;
         waitpid(pids[i], &wstatus, 0);
     }
 
-    if (doc)
+   if (doc)
         fz_drop_document(ctx, doc);
     fz_drop_context(ctx);
 
-    if (use_shared_font_cache)
-        cleanup_shared_font_cache();
+    cleanup_shared_font_cache();
     free(pids);
-
+    
     return temp_dir;
 }
 

--- a/go/internal/bridge/bridge.c
+++ b/go/internal/bridge/bridge.c
@@ -3,7 +3,8 @@
 // (approx. 3x slower overall)
 // so, use one function that writes to disk instead, much less overhead.
 // this is mostly pre existing logic just written to be used via Go.
-// additionally, the raw 'binary' format is used for performance and less disk usage. json gets very taxing on thousands of chars.
+// additionally, the raw 'binary' format is used for performance and less disk usage. json gets very taxing on thousands
+// of chars.
 
 #include "bridge.h"
 #include <stdlib.h>
@@ -21,14 +22,15 @@
 #define EDGE_MAX_WIDTH 3.0
 #define FZ_STORE_SIZE 256 * 1024 * 1024
 
-typedef struct
+    typedef struct
 {
     fz_device super;
-    fz_device* stext_dev;  
+    fz_device* stext_dev;
     edge_array* edges;
 } combined_device;
 
-typedef struct {
+typedef struct
+{
     fz_font* font;
     unsigned char flags;
 } font_cache_entry;
@@ -37,20 +39,28 @@ typedef struct {
    Uses process-shared mutex to synchronize access between workers.
    Persists across all pages and all workers to maximize cache reuse. */
 #define FONT_CACHE_SIZE 256
-typedef struct {
+typedef struct
+{
     pthread_mutex_t lock;
     font_cache_entry entries[FONT_CACHE_SIZE];
     int len;
 } shared_font_cache;
 
 static shared_font_cache* global_font_cache = NULL;
+static font_cache_entry local_font_cache[FONT_CACHE_SIZE];
+static int local_font_cache_len = 0;
+static int use_shared_font_cache = 0;
+
+static void reset_local_font_cache(void)
+{
+    local_font_cache_len = 0;
+}
 
 /* Initialize shared font cache (call in parent before fork) */
-static int init_shared_font_cache(void) {
-    global_font_cache = mmap(NULL, sizeof(shared_font_cache), 
-                             PROT_READ | PROT_WRITE, 
-                             MAP_SHARED | MAP_ANONYMOUS, 
-                             -1, 0);
+static int init_shared_font_cache(void)
+{
+    global_font_cache =
+        mmap(NULL, sizeof(shared_font_cache), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (global_font_cache == MAP_FAILED)
         return -1;
 
@@ -59,8 +69,9 @@ static int init_shared_font_cache(void) {
     pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
     int ret = pthread_mutex_init(&global_font_cache->lock, &attr);
     pthread_mutexattr_destroy(&attr);
-    
-    if (ret != 0) {
+
+    if (ret != 0)
+    {
         munmap(global_font_cache, sizeof(shared_font_cache));
         global_font_cache = NULL;
         return -1;
@@ -71,7 +82,8 @@ static int init_shared_font_cache(void) {
 }
 
 /* Cleanup shared font cache (call after all workers finish) */
-static void cleanup_shared_font_cache(void) {
+static void cleanup_shared_font_cache(void)
+{
     if (!global_font_cache)
         return;
     pthread_mutex_destroy(&global_font_cache->lock);
@@ -80,41 +92,89 @@ static void cleanup_shared_font_cache(void) {
 }
 
 /* Lookup or add font to shared cache. Returns flags for the font. */
-static unsigned char get_font_flags(fz_context* ctx, fz_font* f) {
-    if (!f || !global_font_cache)
+static unsigned char get_font_flags(fz_context* ctx, fz_font* f)
+{
+    if (!f)
         return 0;
 
-    pthread_mutex_lock(&global_font_cache->lock);
+    if (use_shared_font_cache && global_font_cache)
+    {
+        pthread_mutex_lock(&global_font_cache->lock);
 
-    for (int i = 0; i < global_font_cache->len; i++) {
-        if (global_font_cache->entries[i].font == f) {
-            unsigned char flags = global_font_cache->entries[i].flags;
-            pthread_mutex_unlock(&global_font_cache->lock);
-            return flags;
+        for (int i = 0; i < global_font_cache->len; i++)
+        {
+            if (global_font_cache->entries[i].font == f)
+            {
+                unsigned char flags = global_font_cache->entries[i].flags;
+                pthread_mutex_unlock(&global_font_cache->lock);
+                return flags;
+            }
         }
+
+        unsigned char flags = 0;
+        if (fz_font_is_bold(ctx, f))
+            flags |= 1;
+        if (fz_font_is_italic(ctx, f))
+            flags |= 2;
+        if (fz_font_is_monospaced(ctx, f))
+            flags |= 4;
+
+        if (global_font_cache->len < FONT_CACHE_SIZE)
+        {
+            global_font_cache->entries[global_font_cache->len].font = f;
+            global_font_cache->entries[global_font_cache->len].flags = flags;
+            global_font_cache->len++;
+        }
+
+        pthread_mutex_unlock(&global_font_cache->lock);
+        return flags;
+    }
+
+    for (int i = 0; i < local_font_cache_len; i++)
+    {
+        if (local_font_cache[i].font == f)
+            return local_font_cache[i].flags;
     }
 
     unsigned char flags = 0;
-    if (fz_font_is_bold(ctx, f)) flags |= 1;
-    if (fz_font_is_italic(ctx, f)) flags |= 2;
-    if (fz_font_is_monospaced(ctx, f)) flags |= 4;
+    if (fz_font_is_bold(ctx, f))
+        flags |= 1;
+    if (fz_font_is_italic(ctx, f))
+        flags |= 2;
+    if (fz_font_is_monospaced(ctx, f))
+        flags |= 4;
 
-    if (global_font_cache->len < FONT_CACHE_SIZE) {
-        global_font_cache->entries[global_font_cache->len].font = f;
-        global_font_cache->entries[global_font_cache->len].flags = flags;
-        global_font_cache->len++;
+    if (local_font_cache_len < FONT_CACHE_SIZE)
+    {
+        local_font_cache[local_font_cache_len].font = f;
+        local_font_cache[local_font_cache_len].flags = flags;
+        local_font_cache_len++;
     }
 
-    pthread_mutex_unlock(&global_font_cache->lock);
     return flags;
 }
 
-static void mupdf_warning_callback(void* user, const char* message) {
+static int should_skip_images(void)
+{
+    static int init = 0;
+    static int skip = 0;
+    if (!init)
+    {
+        const char* v = getenv("PYMUPDF_SKIP_IMAGES");
+        skip = (v && v[0] != '\0' && v[0] != '0') ? 1 : 0;
+        init = 1;
+    }
+    return skip;
+}
+
+static void mupdf_warning_callback(void* user, const char* message)
+{
     (void)user;
     (void)message;
 }
 
-static void mupdf_error_callback(void* user, const char* message) {
+static void mupdf_error_callback(void* user, const char* message)
+{
     (void)user;
     (void)message;
 }
@@ -181,8 +241,8 @@ static void combined_stroke_path(fz_context* ctx, fz_device* dev, const fz_path*
         cdev->stext_dev->stroke_path(ctx, cdev->stext_dev, path, stroke, ctm, cs, color, alpha, cp);
 }
 
-static void combined_fill_text(fz_context* ctx, fz_device* dev, const fz_text* text, fz_matrix ctm,
-                               fz_colorspace* cs, const float* color, float alpha, fz_color_params cp)
+static void combined_fill_text(fz_context* ctx, fz_device* dev, const fz_text* text, fz_matrix ctm, fz_colorspace* cs,
+                               const float* color, float alpha, fz_color_params cp)
 {
     combined_device* cdev = (combined_device*)dev;
     if (cdev->stext_dev && cdev->stext_dev->fill_text)
@@ -204,8 +264,8 @@ static void combined_clip_text(fz_context* ctx, fz_device* dev, const fz_text* t
         cdev->stext_dev->clip_text(ctx, cdev->stext_dev, text, ctm, scissor);
 }
 
-static void combined_clip_stroke_text(fz_context* ctx, fz_device* dev, const fz_text* text, const fz_stroke_state* stroke,
-                                      fz_matrix ctm, fz_rect scissor)
+static void combined_clip_stroke_text(fz_context* ctx, fz_device* dev, const fz_text* text,
+                                      const fz_stroke_state* stroke, fz_matrix ctm, fz_rect scissor)
 {
     combined_device* cdev = (combined_device*)dev;
     if (cdev->stext_dev && cdev->stext_dev->clip_stroke_text)
@@ -219,24 +279,30 @@ static void combined_ignore_text(fz_context* ctx, fz_device* dev, const fz_text*
         cdev->stext_dev->ignore_text(ctx, cdev->stext_dev, text, ctm);
 }
 
-static void combined_fill_shade(fz_context* ctx, fz_device* dev, fz_shade* shd, fz_matrix ctm, float alpha, fz_color_params cp)
+static void combined_fill_shade(fz_context* ctx, fz_device* dev, fz_shade* shd, fz_matrix ctm, float alpha,
+                                fz_color_params cp)
 {
     combined_device* cdev = (combined_device*)dev;
     if (cdev->stext_dev && cdev->stext_dev->fill_shade)
         cdev->stext_dev->fill_shade(ctx, cdev->stext_dev, shd, ctm, alpha, cp);
 }
 
-static void combined_fill_image(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm, float alpha, fz_color_params cp)
+static void combined_fill_image(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm, float alpha,
+                                fz_color_params cp)
 {
     combined_device* cdev = (combined_device*)dev;
+    if (should_skip_images())
+        return;
     if (cdev->stext_dev && cdev->stext_dev->fill_image)
         cdev->stext_dev->fill_image(ctx, cdev->stext_dev, img, ctm, alpha, cp);
 }
 
-static void combined_fill_image_mask(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm,
-                                     fz_colorspace* cs, const float* color, float alpha, fz_color_params cp)
+static void combined_fill_image_mask(fz_context* ctx, fz_device* dev, fz_image* img, fz_matrix ctm, fz_colorspace* cs,
+                                     const float* color, float alpha, fz_color_params cp)
 {
     combined_device* cdev = (combined_device*)dev;
+    if (should_skip_images())
+        return;
     if (cdev->stext_dev && cdev->stext_dev->fill_image_mask)
         cdev->stext_dev->fill_image_mask(ctx, cdev->stext_dev, img, ctm, cs, color, alpha, cp);
 }
@@ -318,7 +384,8 @@ static void write_all_char_data(FILE* out, fz_context* ctx, fz_stext_page* stext
     (void)expected_total; // could assert match
 }
 
-static int count_links(fz_link* links) {
+static int count_links(fz_link* links)
+{
     int count = 0;
     for (fz_link* l = links; l; l = l->next)
         count++;
@@ -394,6 +461,8 @@ static int extract_page_to_file(fz_context* ctx, fz_document* doc, int page_num,
 
         for (fz_stext_block* block = stext->first_block; block; block = block->next)
         {
+            if (block->type != FZ_STEXT_BLOCK_TEXT)
+                continue;
 
             if (total_blocks >= blocks_capacity)
             {
@@ -475,7 +544,8 @@ static int extract_page_to_file(fz_context* ctx, fz_document* doc, int page_num,
         if (edges.count > 0)
             fwrite(edges.items, sizeof(edge), edges.count, out);
 
-        for (fz_link* l = page_links; l; l = l->next) {
+        for (fz_link* l = page_links; l; l = l->next)
+        {
             fwrite(&l->rect, sizeof(fz_rect), 1, out);
             const char* uri = l->uri ? l->uri : "";
             int uri_len = strlen(uri);
@@ -486,7 +556,6 @@ static int extract_page_to_file(fz_context* ctx, fz_document* doc, int page_num,
 
         fclose(out);
         out = NULL;
-
     }
     fz_always(ctx)
     {
@@ -523,19 +592,20 @@ char* extract_all_pages(const char* pdf_path)
     snprintf(temp_dir, 256, ".pymupdfllm_c_%ld_%u", (long)time(NULL), (unsigned)getpid());
     mkdir(temp_dir, 0755);
 
-    if (init_shared_font_cache() != 0) {
+    use_shared_font_cache = 0;
+    global_font_cache = NULL;
+    reset_local_font_cache();
+
+    fz_context* ctx = fz_new_context(NULL, NULL, FZ_STORE_SIZE);
+
+    if (!ctx)
+    {
+        cleanup_shared_font_cache();
         free(temp_dir);
         return NULL;
     }
-
-    fz_context* ctx = fz_new_context(NULL, NULL, FZ_STORE_SIZE);
     fz_set_warning_callback(ctx, mupdf_warning_callback, NULL);
     fz_set_error_callback(ctx, mupdf_error_callback, NULL);
-
-    if (!ctx) {
-        cleanup_shared_font_cache();        free(temp_dir);
-        return NULL;
-    }
 
     fz_document* doc = NULL;
     int page_count = 0;
@@ -552,17 +622,20 @@ char* extract_all_pages(const char* pdf_path)
         error = 1;
     }
 
-    if (error || page_count == 0) {
+    if (error || page_count == 0)
+    {
         if (doc)
             fz_drop_document(ctx, doc);
         fz_drop_context(ctx);
-        cleanup_shared_font_cache();        free(temp_dir);
+        cleanup_shared_font_cache();
+        free(temp_dir);
         return NULL;
     }
 
     int num_workers = sysconf(_SC_NPROCESSORS_ONLN);
-    const char *workers_env = getenv("PYMUPDF_WORKERS");
-    if (workers_env && workers_env[0] != '\0') {
+    const char* workers_env = getenv("PYMUPDF_WORKERS");
+    if (workers_env && workers_env[0] != '\0')
+    {
         long w = strtol(workers_env, NULL, 10);
         if (w > 0)
             num_workers = (int)w;
@@ -571,22 +644,62 @@ char* extract_all_pages(const char* pdf_path)
         num_workers = 4;
 
     int threshold = (10 > num_workers * 2) ? 10 : num_workers * 2;
-    if (page_count < threshold) {
-        num_workers = 1;  /* force sequential */
+    if (page_count < threshold)
+    {
+        num_workers = 1; /* force sequential */
     }
 
-    pid_t* pids = calloc(num_workers, sizeof(pid_t));
-    if (!pids) {
+    if (num_workers > 1)
+    {
+        if (init_shared_font_cache() != 0)
+        {
+            if (doc)
+                fz_drop_document(ctx, doc);
+            fz_drop_context(ctx);
+            free(temp_dir);
+            return NULL;
+        }
+        use_shared_font_cache = 1;
+    }
+    else
+    {
+        use_shared_font_cache = 0;
+        reset_local_font_cache();
+    }
+
+    if (num_workers == 1)
+    {
+        for (int p = 0; p < page_count; p++)
+        {
+            char filename[512];
+            snprintf(filename, sizeof(filename), "%s/page_%03d.raw", temp_dir, p + 1);
+            if (extract_page_to_file(ctx, doc, p, filename) != 0)
+                fprintf(stderr, "Warning: failed to extract page %d\n", p + 1);
+        }
+
         if (doc)
             fz_drop_document(ctx, doc);
         fz_drop_context(ctx);
-        cleanup_shared_font_cache();        free(temp_dir);
+        return temp_dir;
+    }
+
+    pid_t* pids = calloc(num_workers, sizeof(pid_t));
+    if (!pids)
+    {
+        if (doc)
+            fz_drop_document(ctx, doc);
+        fz_drop_context(ctx);
+        if (use_shared_font_cache)
+            cleanup_shared_font_cache();
+        free(temp_dir);
         return NULL;
     }
     int created = 0;
 
-    for (int i = 0; i < num_workers; i++) {
-        int start = i;        if (start >= page_count)
+    for (int i = 0; i < num_workers; i++)
+    {
+        int start = i;
+        if (start >= page_count)
             break;
 
         pid_t pid = fork();
@@ -595,7 +708,8 @@ char* extract_all_pages(const char* pdf_path)
             perror("fork");
             continue;
         }
-        if (pid == 0) {
+        if (pid == 0)
+        {
             /* CHILD: open its own context/document and process pages in round-robin */
             fz_context* child_ctx = fz_new_context(NULL, NULL, FZ_STORE_SIZE);
             if (!child_ctx)
@@ -604,11 +718,13 @@ char* extract_all_pages(const char* pdf_path)
             fz_set_error_callback(child_ctx, mupdf_error_callback, NULL);
 
             fz_document* child_doc = NULL;
-            fz_try(child_ctx) {
+            fz_try(child_ctx)
+            {
                 fz_register_document_handlers(child_ctx);
                 child_doc = fz_open_document(child_ctx, pdf_path);
             }
-            fz_catch(child_ctx) {
+            fz_catch(child_ctx)
+            {
                 if (child_doc)
                     fz_drop_document(child_ctx, child_doc);
                 fz_drop_context(child_ctx);
@@ -623,7 +739,8 @@ char* extract_all_pages(const char* pdf_path)
             if (child_do_profile)
                 clock_gettime(CLOCK_MONOTONIC, &child_t0);
 
-            for (int p = start; p < page_count; p += num_workers) {
+            for (int p = start; p < page_count; p += num_workers)
+            {
                 char filename[512];
                 snprintf(filename, sizeof(filename), "%s/page_%03d.raw", temp_dir, p + 1);
                 if (extract_page_to_file(child_ctx, child_doc, p, filename) != 0)
@@ -631,7 +748,8 @@ char* extract_all_pages(const char* pdf_path)
                 pages_processed++;
             }
 
-            if (child_do_profile) {
+            if (child_do_profile)
+            {
                 clock_gettime(CLOCK_MONOTONIC, &child_t1);
                 double sec = (child_t1.tv_sec - child_t0.tv_sec) + (child_t1.tv_nsec - child_t0.tv_nsec) * 1e-9;
                 fprintf(stderr, "CHILD PROFILE pid=%d pages=%d total=%.3f s\n", (int)getpid(), pages_processed, sec);
@@ -640,24 +758,27 @@ char* extract_all_pages(const char* pdf_path)
             if (child_doc)
                 fz_drop_document(child_ctx, child_doc);
             fz_drop_context(child_ctx);
-            _exit(0);        }
+            _exit(0);
+        }
         pids[created++] = pid;
     }
 
     /* Using round-robin forked workers; no pipe writes necessary. Parent simply waits for children. */
 
-    for (int i = 0; i < created; i++) {
+    for (int i = 0; i < created; i++)
+    {
         int wstatus;
         waitpid(pids[i], &wstatus, 0);
     }
 
-   if (doc)
+    if (doc)
         fz_drop_document(ctx, doc);
     fz_drop_context(ctx);
 
-    cleanup_shared_font_cache();
+    if (use_shared_font_cache)
+        cleanup_shared_font_cache();
     free(pids);
-    
+
     return temp_dir;
 }
 


### PR DESCRIPTION
Optimize performance.

On `nist.pdf` it gave mild gains of `300ms` -> `250ms`.

On a 1600 page document it gave gains of `1s` -> `600ms`.


**Go side**:
* refactored the main extraction loop in `go/cmd/tojson/main.go` to use separate io and cpu worker pools
* buffer pool for efficient memory reuse
* stream output directly (no temp file)
* added command-line flags for cpu and memory profiling

**C side**:
* sequential fallback for small pdfs and a cap on worker count for moderate-sized documents.
* shared font cache initialization is now conditional based on parallel execution
* remove short or duplicate edges so the (slower) Go code can have less work
* disabled unused device callbacks for image and shade rendering

Also has some font flag fixes to get as many bold and italic as possible (not false positives, of couse)