### PR TITLE
refactor(table): extract pipeline architecture for improved modularity

### DIFF
--- a/go/internal/table/grid.go
+++ b/go/internal/table/grid.go
@@ -1,0 +1,197 @@
+package table
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/fibrumpdf/go/internal/geometry"
+)
+
+type GridNormalizeOptions struct {
+	PreserveEmptyColumns bool
+	NormalizeColumns     bool
+	PageRect             geometry.Rect
+}
+
+type Grid struct {
+	Table *Table
+}
+
+func NewTableGrid(tbl *Table) *Grid {
+	return &Grid{Table: tbl}
+}
+
+func (g *Grid) Normalize(opts GridNormalizeOptions) {
+	if g == nil || g.Table == nil || len(g.Table.Rows) == 0 {
+		return
+	}
+	g.pruneEmptyRows()
+	if len(g.Table.Rows) == 0 {
+		return
+	}
+	g.padRowsToMaxCols()
+	if !opts.PreserveEmptyColumns {
+		g.dropEmptyColumns()
+	}
+	g.normalizeRowWidths()
+	if opts.NormalizeColumns {
+		g.normalizeColumns(opts.PageRect)
+		g.pruneEmptyRows()
+		if !opts.PreserveEmptyColumns {
+			g.dropEmptyColumns()
+		}
+		g.normalizeRowWidths()
+	}
+}
+
+func (g *Grid) pruneEmptyRows() {
+	validRows := g.Table.Rows[:0]
+	for _, row := range g.Table.Rows {
+		for _, c := range row.Cells {
+			if c.BBox.IsEmpty() {
+				continue
+			}
+			validRows = append(validRows, row)
+			break
+		}
+	}
+	g.Table.Rows = validRows
+}
+
+func (g *Grid) padRowsToMaxCols() {
+	maxCols := 0
+	for _, row := range g.Table.Rows {
+		if len(row.Cells) > maxCols {
+			maxCols = len(row.Cells)
+		}
+	}
+	if maxCols == 0 {
+		return
+	}
+	for r := range g.Table.Rows {
+		row := &g.Table.Rows[r]
+		if len(row.Cells) >= maxCols {
+			continue
+		}
+		padded := make([]Cell, maxCols)
+		copy(padded, row.Cells)
+		row.Cells = padded
+	}
+}
+
+func (g *Grid) dropEmptyColumns() {
+	if len(g.Table.Rows) == 0 {
+		return
+	}
+	colCount := len(g.Table.Rows[0].Cells)
+	if colCount == 0 {
+		return
+	}
+	keepCols := make([]bool, colCount)
+	for _, row := range g.Table.Rows {
+		for c, cell := range row.Cells {
+			if !cell.BBox.IsEmpty() || strings.TrimSpace(cell.Text) != "" {
+				keepCols[c] = true
+			}
+		}
+	}
+	newColCount := 0
+	for _, k := range keepCols {
+		if k {
+			newColCount++
+		}
+	}
+	if newColCount == 0 || newColCount >= colCount {
+		return
+	}
+	for r := range g.Table.Rows {
+		oldCells := g.Table.Rows[r].Cells
+		newCells := make([]Cell, 0, newColCount)
+		for c, cell := range oldCells {
+			if c < len(keepCols) && keepCols[c] {
+				newCells = append(newCells, cell)
+			}
+		}
+		g.Table.Rows[r].Cells = newCells
+	}
+}
+
+func (g *Grid) normalizeRowWidths() {
+	if len(g.Table.Rows) == 0 {
+		return
+	}
+	colCount := len(g.Table.Rows[0].Cells)
+	for r := 1; r < len(g.Table.Rows); r++ {
+		row := &g.Table.Rows[r]
+		if len(row.Cells) != colCount {
+			if len(row.Cells) > colCount {
+				row.Cells = row.Cells[:colCount]
+			} else {
+				padded := make([]Cell, colCount)
+				copy(padded, row.Cells)
+				row.Cells = padded
+			}
+		}
+	}
+}
+
+func (g *Grid) normalizeColumns(pageRect geometry.Rect) {
+	if g.Table == nil || len(g.Table.Rows) == 0 {
+		return
+	}
+	xCoords := make(map[int]bool)
+	for _, row := range g.Table.Rows {
+		for _, cell := range row.Cells {
+			if cell.BBox.IsEmpty() {
+				continue
+			}
+			xCoords[cordToInt(float64(cell.BBox.X0))] = true
+			xCoords[cordToInt(float64(cell.BBox.X1))] = true
+		}
+	}
+	sortedX := make([]int, 0, len(xCoords))
+	for x := range xCoords {
+		sortedX = append(sortedX, x)
+	}
+	sort.Ints(sortedX)
+	var cols [][2]float32
+	if len(sortedX) > 0 {
+		colTol := int(pageRect.Width() * colXTolRatio * cordScale)
+		colTol = max(colTol, 2000)
+		for i := 0; i < len(sortedX)-1; {
+			c0 := sortedX[i]
+			j := i + 1
+			for j < len(sortedX) && sortedX[j]-c0 < colTol {
+				j++
+			}
+			if j >= len(sortedX) {
+				break
+			}
+			cols = append(cols, [2]float32{float32(c0) / cordScale, float32(sortedX[j]) / cordScale})
+			i = j
+		}
+	}
+	if len(cols) == 0 {
+		return
+	}
+	for r := range g.Table.Rows {
+		row := &g.Table.Rows[r]
+		newCells := make([]Cell, len(cols))
+		for _, cell := range row.Cells {
+			if cell.BBox.IsEmpty() {
+				continue
+			}
+			bestCol, maxOvr := -1, float32(0)
+			for ci, col := range cols {
+				ovr := geometry.Min32(cell.BBox.X1, col[1]) - geometry.Max32(cell.BBox.X0, col[0])
+				if ovr > maxOvr {
+					maxOvr, bestCol = ovr, ci
+				}
+			}
+			if bestCol >= 0 && (newCells[bestCol].BBox.IsEmpty() || maxOvr > newCells[bestCol].BBox.Width()*0.5) {
+				newCells[bestCol] = cell
+			}
+		}
+		row.Cells = newCells
+	}
+}

--- a/go/internal/table/pipeline.go
+++ b/go/internal/table/pipeline.go
@@ -1,0 +1,797 @@
+package table
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/fibrumpdf/go/internal/geometry"
+	"github.com/fibrumpdf/go/internal/models"
+	rawdata "github.com/fibrumpdf/go/internal/raw"
+	"github.com/fibrumpdf/go/internal/textutil"
+)
+
+// ExtractAndConvertTables runs a linear extraction flow with boundary checks only.
+func ExtractAndConvertTables(raw *rawdata.PageData) []models.Block {
+	if raw == nil {
+		return nil
+	}
+	pipeline := newTableExtractionPipeline()
+	return pipeline.run(raw)
+}
+
+type tableExtractionPipeline struct {
+	detector     tableDetector
+	materializer tableMaterializer
+	selector     tableSelector
+	converter    tableConverter
+}
+
+type detectedTables struct{ tables []Table }
+type materializedTables struct{ tables []Table }
+type selectedTables struct{ tables []Table }
+
+func newTableExtractionPipeline() tableExtractionPipeline {
+	return tableExtractionPipeline{}
+}
+
+func (p tableExtractionPipeline) run(raw *rawdata.PageData) []models.Block {
+	detected := p.detector.run(raw)
+	selected := selectedTables{}
+	if len(detected.tables) > 0 {
+		materialized := p.materializer.run(raw, detected)
+		selected = p.selector.run(raw.PageRect(), raw, materialized)
+	}
+	if len(selected.tables) == 0 {
+		return nil
+	}
+	return p.converter.run(selected)
+}
+
+type tableDetector struct{}
+
+func (s tableDetector) run(raw *rawdata.PageData) detectedTables {
+	pageRect := raw.PageRect()
+	// Try grid-based detection first (requires edges)
+	if len(raw.Edges) >= 3 && (len(raw.Edges) <= maxEdgesForGrid || len(raw.Chars) <= heavyCharCount) {
+		tables := detectTables(raw.Edges, pageRect, raw.PageNumber)
+		if tables != nil && !tables.isEmpty() {
+			return detectedTables{tables: tables.Tables}
+		}
+	}
+	// No grid tables found
+	return detectedTables{}
+}
+
+type tableMaterializer struct{}
+
+func (s tableMaterializer) run(raw *rawdata.PageData, in detectedTables) materializedTables {
+	if len(in.tables) == 0 {
+		return materializedTables{}
+	}
+	tables := in.tables
+	for ti := range tables {
+		tbl := &tables[ti]
+		tableChars := charsNearRect(raw.Chars, tbl.BBox)
+		if len(tableChars) == 0 {
+			continue
+		}
+		for ri := range tbl.Rows {
+			for ci := range tbl.Rows[ri].Cells {
+				cell := &tbl.Rows[ri].Cells[ci]
+				if cell.BBox.IsEmpty() {
+					continue
+				}
+				cell.BBox = shrinkCellToContent(cell.BBox, tableChars)
+				cell.Text = extractTextInRectFromChars(tableChars, cell.BBox, !tbl.RuledTable)
+				if cell.Text == "" {
+					cell.Text = extractTextInRect(raw, cell.BBox)
+				}
+			}
+		}
+		cleanupMaterializedTable(tbl)
+	}
+	return materializedTables{tables: tables}
+}
+
+type tableSelector struct{}
+
+func (s tableSelector) run(pageRect geometry.Rect, raw *rawdata.PageData, in materializedTables) selectedTables {
+	if len(in.tables) == 0 {
+		return selectedTables{}
+	}
+	candidates := make([]Table, 0, len(in.tables))
+	for _, tbl := range in.tables {
+		if !hasTableShape(tbl) || isTableOversized(tbl.BBox, pageRect) {
+			continue
+		}
+		candidates = append(candidates, tbl)
+	}
+	if len(candidates) == 0 {
+		return selectedTables{}
+	}
+	return selectedTables{tables: deduplicateTables(candidates)}
+}
+
+type tableConverter struct{}
+
+func (s tableConverter) run(in selectedTables) []models.Block {
+	blocks := make([]models.Block, 0, len(in.tables))
+	for _, tbl := range in.tables {
+		rows, visibleRows := convertTableRows(tbl)
+		if len(rows) < 2 {
+			continue
+		}
+		activeCols := make(map[int]struct{})
+		maxCols := 0
+		rowsWithTwoPopulated := 0
+		for _, row := range rows {
+			if len(row.Cells) > maxCols {
+				maxCols = len(row.Cells)
+			}
+			populated := 0
+			for ci, cell := range row.Cells {
+				if len(cell.Spans) > 0 && strings.TrimSpace(cell.Spans[0].Text) != "" {
+					populated++
+					activeCols[ci] = struct{}{}
+				}
+			}
+			if populated >= 2 {
+				rowsWithTwoPopulated++
+			}
+		}
+		colCount := len(activeCols)
+		if tbl.RuledTable {
+			if colCount < 2 {
+				colCount = maxCols
+			}
+			if visibleRows == 0 {
+				if maxCols < 3 || len(rows) < 3 {
+					continue
+				}
+				visibleRows = len(rows)
+			}
+			if colCount < 2 || rowsWithTwoPopulated == 0 {
+				if maxCols < 3 || len(rows) < 3 {
+					continue
+				}
+			}
+		} else {
+			if visibleRows == 0 || colCount < 2 || rowsWithTwoPopulated < 2 {
+				continue
+			}
+			if float32(rowsWithTwoPopulated)/float32(visibleRows) < 0.25 {
+				continue
+			}
+		}
+
+		blocks = append(blocks, models.Block{
+			Type:      models.BlockTable,
+			BBox:      models.BBox{tbl.BBox.X0, tbl.BBox.Y0, tbl.BBox.X1, tbl.BBox.Y1},
+			RowCount:  visibleRows,
+			ColCount:  colCount,
+			CellCount: visibleRows * colCount,
+			Rows:      rows,
+		})
+	}
+	return blocks
+}
+
+func hasTableShape(tbl Table) bool {
+	if len(tbl.Rows) < 2 {
+		return false
+	}
+	rowsWithTwoCols := 0
+	activeCols := make(map[int]struct{})
+	for _, row := range tbl.Rows {
+		if len(row.Cells) >= 2 {
+			rowsWithTwoCols++
+		}
+		for ci, cell := range row.Cells {
+			if strings.TrimSpace(cell.Text) != "" {
+				activeCols[ci] = struct{}{}
+			}
+		}
+	}
+	return rowsWithTwoCols >= 1 && len(activeCols) >= 2
+}
+
+func isTableOversized(tableRect, pageRect geometry.Rect) bool {
+	if tableRect.IsEmpty() || pageRect.IsEmpty() {
+		return true
+	}
+	return tableRect.Height()/pageRect.Height() > 0.97 || tableRect.Width()/pageRect.Width() > 0.99
+}
+
+func deduplicateTables(tables []Table) []Table {
+	keep := make([]bool, len(tables))
+	for i := range keep {
+		keep[i] = true
+	}
+	for i := 0; i < len(tables); i++ {
+		if !keep[i] {
+			continue
+		}
+		for j := i + 1; j < len(tables); j++ {
+			if !keep[j] {
+				continue
+			}
+			if tables[i].BBox.IoU(tables[j].BBox) <= 0.95 {
+				continue
+			}
+			if tableScore(tables[i]) >= tableScore(tables[j]) {
+				keep[j] = false
+			} else {
+				keep[i] = false
+				break
+			}
+		}
+	}
+	out := make([]Table, 0, len(tables))
+	for i, ok := range keep {
+		if ok {
+			out = append(out, tables[i])
+		}
+	}
+	return out
+}
+
+func tableScore(tbl Table) int {
+	if len(tbl.Rows) == 0 {
+		return 0
+	}
+	return len(tbl.Rows)*100 + len(tbl.Rows[0].Cells)
+}
+
+func charsNearRect(chars []rawdata.Char, rect geometry.Rect) []rawdata.Char {
+	if len(chars) == 0 {
+		return nil
+	}
+	out := make([]rawdata.Char, 0, min(256, len(chars)))
+	x0, y0, x1, y1 := rect.X0-2, rect.Y0-2, rect.X1+2, rect.Y1+2
+	for i := range chars {
+		ch := &chars[i]
+		if ch.BBox.X0 < x1 && ch.BBox.X1 > x0 && ch.BBox.Y0 < y1 && ch.BBox.Y1 > y0 {
+			out = append(out, *ch)
+		}
+	}
+	return out
+}
+
+func shrinkCellToContent(cell geometry.Rect, chars []rawdata.Char) geometry.Rect {
+	x0, y0, x1, y1 := cell.X0-2, cell.Y0-2, cell.X1+2, cell.Y1+2
+	var content geometry.Rect
+	for i := range chars {
+		ch := &chars[i]
+		if ch.BBox.X0 < x1 && ch.BBox.X1 > x0 && ch.BBox.Y0 < y1 && ch.BBox.Y1 > y0 {
+			r := geometry.Rect{X0: ch.BBox.X0, Y0: ch.BBox.Y0, X1: ch.BBox.X1, Y1: ch.BBox.Y1}
+			if content.IsEmpty() {
+				content = r
+			} else {
+				content = content.Union(r)
+			}
+		}
+	}
+	if content.IsEmpty() {
+		return cell
+	}
+	return geometry.Rect{
+		X0: geometry.Max32(cell.X0, content.X0),
+		Y0: geometry.Max32(cell.Y0, content.Y0),
+		X1: geometry.Min32(cell.X1, content.X1),
+		Y1: geometry.Min32(cell.Y1, content.Y1),
+	}
+}
+
+type charRectSorter struct {
+	indices []int
+	chars   []rawdata.Char
+}
+
+func (s charRectSorter) Len() int      { return len(s.indices) }
+func (s charRectSorter) Swap(i, j int) { s.indices[i], s.indices[j] = s.indices[j], s.indices[i] }
+func (s charRectSorter) Less(i, j int) bool {
+	a := &s.chars[s.indices[i]]
+	b := &s.chars[s.indices[j]]
+	ay, by := (a.BBox.Y0+a.BBox.Y1)*0.5, (b.BBox.Y0+b.BBox.Y1)*0.5
+	lineTol := geometry.Max32(geometry.Max32(a.Size, b.Size)*0.45, 0.8)
+	dyDiff := ay - by
+	if dyDiff < -lineTol {
+		return true
+	}
+	if dyDiff > lineTol {
+		return false
+	}
+	dx := a.BBox.X0 - b.BBox.X0
+	if dx < -0.3 {
+		return true
+	}
+	if dx > 0.3 {
+		return false
+	}
+	return s.indices[i] < s.indices[j]
+}
+
+func extractTextInRect(raw *rawdata.PageData, rect geometry.Rect) string {
+	indices := raw.CharIndicesInRect(rect, nil)
+	if len(indices) == 0 {
+		return ""
+	}
+	sorter := charRectSorter{indices: indices, chars: raw.Chars}
+	sort.Stable(sorter)
+
+	chars := make([]rawdata.Char, len(indices))
+	for i, idx := range indices {
+		chars[i] = raw.Chars[idx]
+	}
+	assembler := textutil.NewTextAssembler(textutil.AssembleOptions{
+		InsertSpaces:       true,
+		Normalize:          true,
+		MergeNumericSpaces: true,
+	})
+	return assembler.AssembleOrderedChars(chars)
+}
+
+func extractTextInRectFromChars(chars []rawdata.Char, rect geometry.Rect, allowOverlapFallback bool) string {
+	if len(chars) == 0 || rect.IsEmpty() {
+		return ""
+	}
+	selected := make([]rawdata.Char, 0, 16)
+	xMin, xMax := rect.X0+0.1, rect.X1-0.1
+	yMin, yMax := rect.Y0+0.1, rect.Y1-0.1
+	for i := range chars {
+		ch := chars[i]
+		cx, cy := (ch.BBox.X0+ch.BBox.X1)*0.5, (ch.BBox.Y0+ch.BBox.Y1)*0.5
+		if cx >= xMin && cx <= xMax && cy >= yMin && cy <= yMax {
+			selected = append(selected, ch)
+		}
+	}
+	if allowOverlapFallback && len(selected) == 0 {
+		for i := range chars {
+			ch := chars[i]
+			if ch.BBox.X0 < rect.X1 && ch.BBox.X1 > rect.X0 && ch.BBox.Y0 < rect.Y1 && ch.BBox.Y1 > rect.Y0 {
+				selected = append(selected, ch)
+			}
+		}
+	}
+	if len(selected) == 0 {
+		return ""
+	}
+	sorter := charRectSorter{indices: make([]int, len(selected)), chars: selected}
+	for i := range sorter.indices {
+		sorter.indices[i] = i
+	}
+	sort.Stable(sorter)
+	ordered := make([]rawdata.Char, len(sorter.indices))
+	for i, idx := range sorter.indices {
+		ordered[i] = selected[idx]
+	}
+
+	lines := splitCharsIntoLines(ordered)
+	assembler := textutil.NewTextAssembler(textutil.AssembleOptions{
+		InsertSpaces:       true,
+		Normalize:          true,
+		MergeNumericSpaces: true,
+	})
+	if len(lines) <= 1 {
+		return assembler.AssembleOrderedChars(ordered)
+	}
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		lineText := strings.TrimSpace(assembler.AssembleOrderedChars(line))
+		if lineText != "" {
+			parts = append(parts, lineText)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "<br>")
+}
+
+func splitCharsIntoLines(chars []rawdata.Char) [][]rawdata.Char {
+	if len(chars) == 0 {
+		return nil
+	}
+	lines := make([][]rawdata.Char, 0, 4)
+	cur := make([]rawdata.Char, 0, 16)
+	lineY := float32(0)
+	for i, ch := range chars {
+		if i == 0 {
+			cur = append(cur, ch)
+			lineY = (ch.BBox.Y0 + ch.BBox.Y1) * 0.5
+			continue
+		}
+		cy := (ch.BBox.Y0 + ch.BBox.Y1) * 0.5
+		lineTol := geometry.Max32(ch.Size*0.7, 1.2)
+		if geometry.Abs32(cy-lineY) > lineTol {
+			sort.SliceStable(cur, func(i, j int) bool { return cur[i].BBox.X0 < cur[j].BBox.X0 })
+			lines = append(lines, cur)
+			cur = make([]rawdata.Char, 0, 16)
+			lineY = cy
+		}
+		cur = append(cur, ch)
+	}
+	if len(cur) > 0 {
+		sort.SliceStable(cur, func(i, j int) bool { return cur[i].BBox.X0 < cur[j].BBox.X0 })
+		lines = append(lines, cur)
+	}
+	return lines
+}
+
+func convertTableRows(tbl Table) ([]models.TableRow, int) {
+	preserveEmptyCols := tbl.RuledTable || shouldPreserveEmptyColumns(tbl)
+	rows := make([]models.TableRow, 0, len(tbl.Rows))
+	visibleRows := 0
+	for _, r := range tbl.Rows {
+		cells := make([]models.TableCell, 0, len(r.Cells))
+		hasVisible := false
+		for _, c := range r.Cells {
+			if c.BBox.IsEmpty() && !preserveEmptyCols {
+				continue
+			}
+			text := strings.TrimSpace(c.Text)
+			var spans []models.Span
+			if text != "" {
+				hasVisible = true
+				spans = []models.Span{{Text: text}}
+			}
+			cells = append(cells, models.TableCell{BBox: models.BBox{c.BBox.X0, c.BBox.Y0, c.BBox.X1, c.BBox.Y1}, Spans: spans})
+		}
+		if len(cells) == 0 {
+			continue
+		}
+		if hasVisible {
+			visibleRows++
+		}
+		rows = append(rows, models.TableRow{BBox: models.BBox{r.BBox.X0, r.BBox.Y0, r.BBox.X1, r.BBox.Y1}, Cells: cells})
+	}
+	return rows, visibleRows
+}
+
+func cleanupMaterializedTable(tbl *Table) {
+	if tbl == nil || len(tbl.Rows) == 0 {
+		return
+	}
+	maxCols := 0
+	for _, row := range tbl.Rows {
+		if len(row.Cells) > maxCols {
+			maxCols = len(row.Cells)
+		}
+	}
+	if maxCols == 0 {
+		return
+	}
+	for i := range tbl.Rows {
+		if len(tbl.Rows[i].Cells) >= maxCols {
+			continue
+		}
+		padded := make([]Cell, maxCols)
+		copy(padded, tbl.Rows[i].Cells)
+		tbl.Rows[i].Cells = padded
+	}
+	if tbl.RuledTable {
+		dropFullyEmptyColumns(tbl)
+		splitPairedLineRows(tbl)
+	} else {
+		dropTextEmptyColumns(tbl)
+		mergeCurrencyValueColumns(tbl)
+	}
+	mergeContinuationRows(tbl)
+}
+
+func dropFullyEmptyColumns(tbl *Table) {
+	if tbl == nil || len(tbl.Rows) == 0 || len(tbl.Rows[0].Cells) == 0 {
+		return
+	}
+	colCount := len(tbl.Rows[0].Cells)
+	keep := make([]bool, colCount)
+	for _, row := range tbl.Rows {
+		for ci := 0; ci < min(colCount, len(row.Cells)); ci++ {
+			if !row.Cells[ci].BBox.IsEmpty() || strings.TrimSpace(row.Cells[ci].Text) != "" {
+				keep[ci] = true
+			}
+		}
+	}
+	newCount := 0
+	for _, ok := range keep {
+		if ok {
+			newCount++
+		}
+	}
+	if newCount == 0 || newCount == colCount {
+		return
+	}
+	for ri := range tbl.Rows {
+		newCells := make([]Cell, 0, newCount)
+		for ci, ok := range keep {
+			if ok && ci < len(tbl.Rows[ri].Cells) {
+				newCells = append(newCells, tbl.Rows[ri].Cells[ci])
+			}
+		}
+		tbl.Rows[ri].Cells = newCells
+	}
+}
+
+func mergeContinuationRows(tbl *Table) {
+	if tbl == nil || len(tbl.Rows) < 2 {
+		return
+	}
+
+	gapLimit := continuationGapLimit(tbl.Rows)
+	keep := make([]Row, 0, len(tbl.Rows))
+	keep = append(keep, tbl.Rows[0])
+
+	for ri := 1; ri < len(tbl.Rows); ri++ {
+		curr := tbl.Rows[ri]
+		prev := &keep[len(keep)-1]
+
+		currCount, currCol := populatedCellInfo(curr)
+		prevCount, _ := populatedCellInfo(*prev)
+		if currCount != 1 || prevCount < 2 || currCol < 0 || currCol >= len(prev.Cells) {
+			keep = append(keep, curr)
+			continue
+		}
+
+		currText := strings.TrimSpace(curr.Cells[currCol].Text)
+		if currText == "" {
+			keep = append(keep, curr)
+			continue
+		}
+		if textHasDigit(currText) || len([]rune(currText)) > 24 {
+			keep = append(keep, curr)
+			continue
+		}
+
+		gap := curr.BBox.Y0 - prev.BBox.Y1
+		if gap > gapLimit {
+			keep = append(keep, curr)
+			continue
+		}
+
+		if curr.BBox.X0 > prev.BBox.X1 || curr.BBox.X1 < prev.BBox.X0 {
+			keep = append(keep, curr)
+			continue
+		}
+
+		mergedText := strings.TrimSpace(prev.Cells[currCol].Text)
+		if mergedText == "" {
+			prev.Cells[currCol].Text = currText
+		} else {
+			prev.Cells[currCol].Text = mergedText + " " + currText
+		}
+		if prev.Cells[currCol].BBox.IsEmpty() {
+			prev.Cells[currCol].BBox = curr.Cells[currCol].BBox
+		} else {
+			prev.Cells[currCol].BBox = prev.Cells[currCol].BBox.Union(curr.Cells[currCol].BBox)
+		}
+		if !curr.BBox.IsEmpty() {
+			if prev.BBox.IsEmpty() {
+				prev.BBox = curr.BBox
+			} else {
+				prev.BBox = prev.BBox.Union(curr.BBox)
+			}
+		}
+	}
+
+	tbl.Rows = keep
+}
+
+func continuationGapLimit(rows []Row) float32 {
+	var heights []float32
+	for _, row := range rows {
+		h := row.BBox.Height()
+		if h > 0 {
+			heights = append(heights, h)
+		}
+	}
+	if len(heights) == 0 {
+		return 0
+	}
+	sort.Slice(heights, func(i, j int) bool { return heights[i] < heights[j] })
+	median := heights[len(heights)/2]
+	return float32(math.Max(float64(median*0.45), 1.5))
+}
+
+func populatedCellInfo(row Row) (count int, lastCol int) {
+	lastCol = -1
+	for ci := range row.Cells {
+		if strings.TrimSpace(row.Cells[ci].Text) == "" {
+			continue
+		}
+		count++
+		lastCol = ci
+	}
+	return count, lastCol
+}
+
+func textHasDigit(text string) bool {
+	for _, r := range text {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+func dropTextEmptyColumns(tbl *Table) {
+	if tbl == nil || len(tbl.Rows) == 0 || len(tbl.Rows[0].Cells) == 0 {
+		return
+	}
+	colCount := len(tbl.Rows[0].Cells)
+	keep := make([]bool, colCount)
+	for _, row := range tbl.Rows {
+		for ci := 0; ci < min(colCount, len(row.Cells)); ci++ {
+			if strings.TrimSpace(row.Cells[ci].Text) != "" {
+				keep[ci] = true
+			}
+		}
+	}
+	newCount := 0
+	for _, ok := range keep {
+		if ok {
+			newCount++
+		}
+	}
+	if newCount == 0 || newCount == colCount {
+		return
+	}
+	for ri := range tbl.Rows {
+		newCells := make([]Cell, 0, newCount)
+		for ci, ok := range keep {
+			if ok && ci < len(tbl.Rows[ri].Cells) {
+				newCells = append(newCells, tbl.Rows[ri].Cells[ci])
+			}
+		}
+		tbl.Rows[ri].Cells = newCells
+	}
+}
+
+func mergeCurrencyValueColumns(tbl *Table) {
+	if tbl == nil || len(tbl.Rows) == 0 || len(tbl.Rows[0].Cells) < 2 {
+		return
+	}
+	colCount := len(tbl.Rows[0].Cells)
+	for ci := 0; ci < colCount-1; ci++ {
+		prefixRows := 0
+		for _, row := range tbl.Rows {
+			if ci+1 >= len(row.Cells) {
+				continue
+			}
+			left := strings.TrimSpace(row.Cells[ci].Text)
+			right := strings.TrimSpace(row.Cells[ci+1].Text)
+			if isCurrencyPrefix(left) && looksNumericValue(right) {
+				prefixRows++
+			}
+		}
+		if prefixRows == 0 {
+			continue
+		}
+		for ri := range tbl.Rows {
+			if ci+1 >= len(tbl.Rows[ri].Cells) {
+				continue
+			}
+			left := strings.TrimSpace(tbl.Rows[ri].Cells[ci].Text)
+			right := strings.TrimSpace(tbl.Rows[ri].Cells[ci+1].Text)
+			if !isCurrencyPrefix(left) || !looksNumericValue(right) {
+				continue
+			}
+			tbl.Rows[ri].Cells[ci+1].Text = left + right
+			tbl.Rows[ri].Cells[ci+1].BBox = tbl.Rows[ri].Cells[ci].BBox.Union(tbl.Rows[ri].Cells[ci+1].BBox)
+			tbl.Rows[ri].Cells[ci] = Cell{}
+		}
+		dropTextEmptyColumns(tbl)
+		colCount = len(tbl.Rows[0].Cells)
+		ci--
+	}
+}
+
+func splitPairedLineRows(tbl *Table) {
+	if tbl == nil || len(tbl.Rows) == 0 {
+		return
+	}
+	rows := make([]Row, 0, len(tbl.Rows))
+	for _, row := range tbl.Rows {
+		populated := 0
+		paired := 0
+		for ci := range row.Cells {
+			text := strings.TrimSpace(row.Cells[ci].Text)
+			if text == "" {
+				continue
+			}
+			populated++
+			parts := splitLineParts(text)
+			if len(parts) != 2 {
+				continue
+			}
+			if len([]rune(parts[0])) > 24 || len([]rune(parts[1])) > 24 {
+				continue
+			}
+			paired++
+		}
+		if populated < 3 || paired < 3 || paired*2 < populated {
+			rows = append(rows, row)
+			continue
+		}
+
+		top := Row{Cells: make([]Cell, len(row.Cells))}
+		bottom := Row{Cells: make([]Cell, len(row.Cells))}
+		for ci := range row.Cells {
+			cell := row.Cells[ci]
+			parts := splitLineParts(cell.Text)
+			if len(parts) == 2 {
+				top.Cells[ci].Text = parts[0]
+				bottom.Cells[ci].Text = parts[1]
+			} else {
+				top.Cells[ci].Text = strings.TrimSpace(cell.Text)
+			}
+			if cell.BBox.IsEmpty() {
+				continue
+			}
+			mid := (cell.BBox.Y0 + cell.BBox.Y1) * 0.5
+			topBBox := geometry.Rect{X0: cell.BBox.X0, Y0: cell.BBox.Y0, X1: cell.BBox.X1, Y1: mid}
+			bottomBBox := geometry.Rect{X0: cell.BBox.X0, Y0: mid, X1: cell.BBox.X1, Y1: cell.BBox.Y1}
+			top.Cells[ci].BBox = topBBox
+			if len(parts) == 2 {
+				bottom.Cells[ci].BBox = bottomBBox
+			}
+			if top.BBox.IsEmpty() {
+				top.BBox = topBBox
+			} else {
+				top.BBox = top.BBox.Union(topBBox)
+			}
+			if len(parts) == 2 {
+				if bottom.BBox.IsEmpty() {
+					bottom.BBox = bottomBBox
+				} else {
+					bottom.BBox = bottom.BBox.Union(bottomBBox)
+				}
+			}
+		}
+		rows = append(rows, top)
+		if !bottom.BBox.IsEmpty() {
+			rows = append(rows, bottom)
+		}
+	}
+	tbl.Rows = rows
+}
+
+func splitLineParts(text string) []string {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	raw := strings.Split(text, "<br>")
+	parts := make([]string, 0, len(raw))
+	for _, p := range raw {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+func isCurrencyPrefix(s string) bool {
+	switch s {
+	case "$", "€", "£", "¥":
+		return true
+	default:
+		return false
+	}
+}
+
+func looksNumericValue(s string) bool {
+	hasDigit := false
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			hasDigit = true
+			continue
+		}
+		switch r {
+		case ',', '.', ' ', '-', '(', ')':
+		default:
+			return false
+		}
+	}
+	return hasDigit
+}

--- a/go/internal/table/table.go
+++ b/go/internal/table/table.go
@@ -2,134 +2,174 @@ package table
 
 import (
 	"math"
+	"slices"
 	"sort"
-	"strings"
 
 	"github.com/fibrumpdf/go/internal/geometry"
 	"github.com/fibrumpdf/go/internal/logger"
-	"github.com/fibrumpdf/go/internal/models"
 	rawdata "github.com/fibrumpdf/go/internal/raw"
-	"github.com/tidwall/rtree"
 )
 
 var Logger = logger.GetLogger("table")
 
-const (
-	snapTolRatio   = 0.005
-	joinTolRatio   = 0.005
-	minCellRatio   = 0.005
-	maxCellWRatio  = 0.95
-	maxCellHRatio  = 0.20
-	splitGapRatio  = 0.10
-	rowYTolRatio   = 0.015
-	colXTolRatio   = 0.003
-	intersectRatio = 0.0015
-	coordScale     = 1000.0
-)
-
-type Edge struct {
-	X0, Y0, X1, Y1 float64
-	Orientation    byte
-}
-
-type Cell struct {
-	BBox geometry.Rect
-	Text string
-}
-
-type Row struct {
-	BBox  geometry.Rect
-	Cells []Cell
-}
-
-type Table struct {
-	BBox geometry.Rect
-	Rows []Row
-}
-
-type TableArray struct{ Tables []Table }
-
-func coordToInt(x float64) int { return int(x*coordScale + 0.5) }
+func cordToInt(x float64) int { return int(x*cordScale + 0.5) }
 
 func hasEdge(edges []Edge, x0, y0, x1, y1, eps float64) bool {
-	for _, e := range edges {
-		if e.Orientation == 'h' {
-			if math.Abs(e.Y0-y0) < eps && math.Abs(e.Y1-y1) < eps &&
-				e.X0-eps <= math.Min(x0, x1) && e.X1+eps >= math.Max(x0, x1) {
-				return true
-			}
-		} else {
-			if math.Abs(e.X0-x0) < eps && math.Abs(e.X1-x1) < eps &&
-				e.Y0-eps <= math.Min(y0, y1) && e.Y1+eps >= math.Max(y0, y1) {
-				return true
+
+	isHorizontal := math.Abs(y0-y1) < eps
+
+	if isHorizontal {
+
+		targetY := (y0 + y1) / 2
+		spanStart, spanEnd := math.Min(x0, x1), math.Max(x0, x1)
+
+		var coveringEdges []struct{ x0, x1 float64 }
+		for _, e := range edges {
+			if e.Orientation == rawdata.EdgeHorizontal && math.Abs(e.Y0-targetY) < eps {
+				coveringEdges = append(coveringEdges, struct{ x0, x1 float64 }{e.X0, e.X1})
 			}
 		}
+
+		return spanIsCovered(coveringEdges, spanStart, spanEnd, eps)
+	} else {
+
+		targetX := (x0 + x1) / 2
+		spanStart, spanEnd := math.Min(y0, y1), math.Max(y0, y1)
+
+		var coveringEdges []struct{ x0, x1 float64 }
+		for _, e := range edges {
+			if e.Orientation == rawdata.EdgeVertical && math.Abs(e.X0-targetX) < eps {
+				coveringEdges = append(coveringEdges, struct{ x0, x1 float64 }{e.Y0, e.Y1})
+			}
+		}
+
+		return spanIsCovered(coveringEdges, spanStart, spanEnd, eps)
 	}
-	return false
 }
 
-func findCells(points []geometry.Point, tr *rtree.RTreeG[geometry.Point], pageRect geometry.Rect, hEdges, vEdges []Edge) []geometry.Rect {
-	if len(points) < 4 {
+func spanIsCovered(segments []struct{ x0, x1 float64 }, spanStart, spanEnd, eps float64) bool {
+	if len(segments) == 0 {
+		return false
+	}
+
+	sort.Slice(segments, func(i, j int) bool { return segments[i].x0 < segments[j].x0 })
+
+	mergedStart := segments[0].x0
+	mergedEnd := segments[0].x1
+	for i := 1; i < len(segments); i++ {
+		if segments[i].x0 <= mergedEnd+eps {
+			if segments[i].x1 > mergedEnd {
+				mergedEnd = segments[i].x1
+			}
+		} else {
+
+			if mergedStart-eps <= spanStart && mergedEnd+eps >= spanEnd {
+				return true
+			}
+			mergedStart = segments[i].x0
+			mergedEnd = segments[i].x1
+		}
+	}
+
+	return mergedStart-eps <= spanStart && mergedEnd+eps >= spanEnd
+}
+
+func findCells(pageRect geometry.Rect, hEdges, vEdges []Edge, avgEdgeSpacing float64) []geometry.Rect {
+	pw, ph := pageRect.Width(), pageRect.Height()
+	minSize, maxW, maxH := geometry.Min32(pw, ph)*minCellRatio, pw*maxCellWRatio, ph*maxCellHRatio
+	eps := avgEdgeSpacing * 0.3
+	if eps < 1.0 {
+		eps = 1.0
+	}
+	gridCols, gridRows := findGridLines(hEdges, vEdges, eps, pageRect)
+	if len(gridCols) < 2 || len(gridRows) < 2 {
 		return nil
 	}
-	pw, ph := pageRect.Width(), pageRect.Height()
-	diag := float32(math.Sqrt(float64(pw*pw + ph*ph)))
-	minSize, maxW, maxH := geometry.Min32(pw, ph)*minCellRatio, pw*maxCellWRatio, ph*maxCellHRatio
-	snapDist, eps := pw*snapTolRatio, float64(diag*intersectRatio)
-	sorted := make([]geometry.Point, len(points))
-	copy(sorted, points)
-	sort.Slice(sorted, func(i, j int) bool {
-		if dy := sorted[i].Y - sorted[j].Y; math.Abs(float64(dy)) > 0.1 {
-			return dy < 0
-		}
-		return sorted[i].X < sorted[j].X
-	})
-	var snapped []geometry.Point
-	for _, p := range sorted {
-		merged := false
-		for i := range snapped {
-			if geometry.Abs32(p.X-snapped[i].X) < snapDist && geometry.Abs32(p.Y-snapped[i].Y) < snapDist {
-				snapped[i].X, snapped[i].Y = (snapped[i].X+p.X)/2, (snapped[i].Y+p.Y)/2
-				merged = true
-				break
-			}
-		}
-		if !merged {
-			snapped = append(snapped, p)
-		}
-	}
+
 	var cells []geometry.Rect
-	for i, p1 := range snapped {
-		for j := i + 1; j < len(snapped); j++ {
-			if float64(snapped[j].Y-p1.Y) > eps {
-				break
-			}
-			p2 := snapped[j]
-			if p2.X <= p1.X+minSize || !hasEdge(hEdges, float64(p1.X), float64(p1.Y), float64(p2.X), float64(p2.Y), eps) {
+	for ri := 0; ri < len(gridRows)-1; ri++ {
+		for ci := 0; ci < len(gridCols)-1; ci++ {
+			cell := geometry.Rect{X0: gridCols[ci], Y0: gridRows[ri], X1: gridCols[ci+1], Y1: gridRows[ri+1]}
+			w, h := cell.Width(), cell.Height()
+			sizeOk := w > minSize && w < maxW && h > minSize && h < maxH
+			if !sizeOk {
 				continue
 			}
-			for _, p3 := range snapped {
-				if p3.Y <= p1.Y+minSize || math.Abs(float64(p3.X-p1.X)) > eps || !hasEdge(vEdges, float64(p1.X), float64(p1.Y), float64(p3.X), float64(p3.Y), eps) {
-					continue
+
+			edges := [4]bool{
+				hasEdge(hEdges, float64(cell.X0), float64(cell.Y0), float64(cell.X1), float64(cell.Y0), eps),
+				hasEdge(hEdges, float64(cell.X0), float64(cell.Y1), float64(cell.X1), float64(cell.Y1), eps),
+				hasEdge(vEdges, float64(cell.X0), float64(cell.Y0), float64(cell.X0), float64(cell.Y1), eps),
+				hasEdge(vEdges, float64(cell.X1), float64(cell.Y0), float64(cell.X1), float64(cell.Y1), eps),
+			}
+			edgeCount := 0
+			for _, ok := range edges {
+				if ok {
+					edgeCount++
 				}
-				found := false
-				tr.Search([2]float64{float64(p2.X) - eps, float64(p3.Y) - eps}, [2]float64{float64(p2.X) + eps, float64(p3.Y) + eps}, func(_, _ [2]float64, _ geometry.Point) bool {
-					if hasEdge(vEdges, float64(p2.X), float64(p2.Y), float64(p2.X), float64(p3.Y), eps) && hasEdge(hEdges, float64(p3.X), float64(p3.Y), float64(p2.X), float64(p3.Y), eps) {
-						found = true
-						return false
-					}
-					return true
-				})
-				if found {
-					cell := geometry.Rect{X0: p1.X, Y0: p1.Y, X1: p2.X, Y1: p3.Y}
-					if w, h := cell.Width(), cell.Height(); w > minSize && w < maxW && h > minSize && h < maxH {
-						cells = append(cells, cell)
-					}
+			}
+
+			minEdges := 2
+			if (len(gridCols) >= 4 && len(gridRows) >= 4) || len(gridCols) >= 6 || len(gridRows) >= 6 {
+				minEdges = 1
+			}
+			if edgeCount >= minEdges {
+				cells = append(cells, cell)
+			}
+		}
+	}
+
+	if len(cells) < 3 && len(gridRows) >= 2 && len(gridCols) >= 2 {
+		cells = cells[:0]
+		for ri := 0; ri < len(gridRows)-1; ri++ {
+			for ci := 0; ci < len(gridCols)-1; ci++ {
+				cell := geometry.Rect{X0: gridCols[ci], Y0: gridRows[ri], X1: gridCols[ci+1], Y1: gridRows[ri+1]}
+				if w, h := cell.Width(), cell.Height(); w > minSize && w < maxW && h > minSize && h < maxH {
+					cells = append(cells, cell)
 				}
 			}
 		}
 	}
+
 	return cells
+}
+
+func findGridLines(hEdges, vEdges []Edge, eps float64, pageRect geometry.Rect) ([]float32, []float32) {
+	xCluster := NewCluster1D(float32(eps))
+	yCluster := NewCluster1D(float32(eps))
+	minVLen := float64(pageRect.Height()) * 0.02
+	minHLen := float64(pageRect.Width()) * 0.02
+	for _, e := range vEdges {
+		edgeLen := math.Abs(e.Y1 - e.Y0)
+		if edgeLen < minVLen {
+			continue
+		}
+		xCluster.Add(float32(e.X0))
+	}
+	for _, e := range hEdges {
+		edgeLen := math.Abs(e.X1 - e.X0)
+		if edgeLen < minHLen {
+			continue
+		}
+		yCluster.Add(float32(e.Y0))
+	}
+	minXCount := 1
+	minYCount := 1
+	var gridCols []float32
+	for i, count := range xCluster.Counts {
+		if count >= minXCount {
+			gridCols = append(gridCols, xCluster.Centers[i])
+		}
+	}
+	var gridRows []float32
+	for i, count := range yCluster.Counts {
+		if count >= minYCount {
+			gridRows = append(gridRows, yCluster.Centers[i])
+		}
+	}
+	slices.Sort(gridCols)
+	slices.Sort(gridRows)
+	return gridCols, gridRows
 }
 
 func deduplicateCells(cells []geometry.Rect) []geometry.Rect {
@@ -182,314 +222,200 @@ func groupCellsIntoTables(cells []geometry.Rect, pageRect geometry.Rect) *TableA
 	if len(cells) == 0 {
 		return nil
 	}
-	splitGap := pageRect.Height() * splitGapRatio
-	var avgH float32
-	for _, c := range cells {
-		avgH += c.Height()
+	assembler := NewDefaultTableAssembler(NewDefaultTableAssemblyConfig())
+	tables := assembler.AssembleFromCells(cells, pageRect)
+	if tables == nil || tables.isEmpty() {
+		return nil
 	}
-	avgH /= float32(len(cells))
-	sortTol := avgH * 0.2
-	sort.Slice(cells, func(i, j int) bool {
-		if dy := cells[i].Y0 - cells[j].Y0; geometry.Abs32(dy) > sortTol {
-			return dy < 0
-		}
-		return cells[i].X0 < cells[j].X0
-	})
-	tables := &TableArray{}
-	var cur *Table
-	prevY1 := float32(-1000)
-	for i := 0; i < len(cells); {
-		rowY0, yTol := cells[i].Y0, pageRect.Height()*rowYTolRatio
-		j := i + 1
-		for j < len(cells) && math.Abs(float64(cells[j].Y0-rowY0)) <= float64(yTol) {
-			j++
-		}
-		gap := rowY0 - prevY1
-		if i > 0 {
-			if g := rowY0 - cells[i-1].Y1; g > gap {
-				gap = g
-			}
-		}
-		if cur == nil || gap > splitGap {
-			tables.Tables = append(tables.Tables, Table{})
-			cur = &tables.Tables[len(tables.Tables)-1]
-			prevY1 = -1000
-		}
-		rowCells := make([]Cell, j-i)
-		for k := 0; k < j-i; k++ {
-			rowCells[k].BBox = cells[i+k]
-		}
-		sort.Slice(rowCells, func(k1, k2 int) bool { return rowCells[k1].BBox.X0 < rowCells[k2].BBox.X0 })
-		row := Row{Cells: rowCells, BBox: rowCells[0].BBox}
-		for k := 1; k < len(rowCells); k++ {
-			row.BBox = row.BBox.Union(rowCells[k].BBox)
-		}
-		cur.BBox = cur.BBox.Union(row.BBox)
-		cur.Rows = append(cur.Rows, row)
-		prevY1 = row.BBox.Y1
-		i = j
-	}
-	normalizeColumns(tables, pageRect)
-	filterValid(tables, pageRect)
-	if len(tables.Tables) == 0 {
+	tables.normalizeColumns(pageRect)
+	if tables.isEmpty() {
 		return nil
 	}
 	return tables
 }
 
-func normalizeColumns(tables *TableArray, pageRect geometry.Rect) {
-	for ti := range tables.Tables {
-		tbl := &tables.Tables[ti]
-		xCoords := make(map[int]bool)
-		for _, row := range tbl.Rows {
-			for _, cell := range row.Cells {
-				if !cell.BBox.IsEmpty() {
-					xCoords[coordToInt(float64(cell.BBox.X0))] = true
-					xCoords[coordToInt(float64(cell.BBox.X1))] = true
-				}
-			}
-		}
-		sortedX := make([]int, 0, len(xCoords))
-		for x := range xCoords {
-			sortedX = append(sortedX, x)
-		}
-		sort.Ints(sortedX)
-		var cols [][2]float32
-		if len(sortedX) > 0 {
-			colTol := int(pageRect.Width() * colXTolRatio * coordScale)
-			if colTol < 2000 {
-				colTol = 2000
-			}
-			for i := 0; i < len(sortedX)-1; {
-				c0 := sortedX[i]
-				j := i + 1
-				for j < len(sortedX) && sortedX[j]-c0 < colTol {
-					j++
-				}
-				if j < len(sortedX) {
-					cols = append(cols, [2]float32{float32(c0) / coordScale, float32(sortedX[j]) / coordScale})
-					i = j
-				} else {
-					break
-				}
-			}
-		}
-		if len(cols) == 0 {
-			continue
-		}
-		for r := range tbl.Rows {
-			row := &tbl.Rows[r]
-			newCells := make([]Cell, len(cols))
-			for _, cell := range row.Cells {
-				if cell.BBox.IsEmpty() {
-					continue
-				}
-				bestCol, maxOvr := -1, float32(0)
-				for ci, col := range cols {
-					ovr := geometry.Min32(cell.BBox.X1, col[1]) - geometry.Max32(cell.BBox.X0, col[0])
-					if ovr > maxOvr {
-						maxOvr, bestCol = ovr, ci
-					}
-				}
-				if bestCol >= 0 && (newCells[bestCol].BBox.IsEmpty() || maxOvr > newCells[bestCol].BBox.Width()*0.5) {
-					newCells[bestCol] = cell
-				}
-			}
-			row.Cells = newCells
-		}
-		pruneEmpty(tbl)
+func adaptiveRowGroupingTolerance(avgH float32, pageRect geometry.Rect) float32 {
+	base := geometry.Max32(avgH*0.35, pageRect.Height()*0.004)
+	minTol := pageRect.Height() * 0.0025
+	maxTol := pageRect.Height() * rowYTolRatio
+	if base < minTol {
+		base = minTol
 	}
+	if base > maxTol {
+		base = maxTol
+	}
+	return base
 }
 
-func pruneEmpty(tbl *Table) {
-	validRows := tbl.Rows[:0]
-	for _, row := range tbl.Rows {
-		for _, c := range row.Cells {
-			if !c.BBox.IsEmpty() {
-				validRows = append(validRows, row)
-				break
-			}
-		}
-	}
-	tbl.Rows = validRows
-	if len(tbl.Rows) == 0 || len(tbl.Rows[0].Cells) == 0 {
-		return
-	}
-	keepCols := make([]bool, len(tbl.Rows[0].Cells))
-	for c := range tbl.Rows[0].Cells {
-		if !tbl.Rows[0].Cells[c].BBox.IsEmpty() {
-			keepCols[c] = true
-		}
-	}
-	newColCount := 0
-	for _, k := range keepCols {
-		if k {
-			newColCount++
-		}
-	}
-	if newColCount > 0 && newColCount < len(tbl.Rows[0].Cells) {
-		for r := range tbl.Rows {
-			oldCells := tbl.Rows[r].Cells
-			newCells := make([]Cell, 0, newColCount)
-			for c, cell := range oldCells {
-				if c < len(keepCols) && keepCols[c] {
-					newCells = append(newCells, cell)
-				}
-			}
-			tbl.Rows[r].Cells = newCells
-		}
-	}
-	if len(tbl.Rows) > 0 {
-		colCount := len(tbl.Rows[0].Cells)
-		for r := 1; r < len(tbl.Rows); r++ {
-			row := &tbl.Rows[r]
-			if len(row.Cells) > colCount {
-				row.Cells = row.Cells[:colCount]
-			} else if len(row.Cells) < colCount {
-				padded := make([]Cell, colCount)
-				copy(padded, row.Cells)
-				row.Cells = padded
-			}
-		}
-	}
-}
-
-func filterValid(tables *TableArray, pageRect geometry.Rect) {
-	valid := tables.Tables[:0]
-	for _, t := range tables.Tables {
-		pruneEmpty(&t)
-		if len(t.Rows) < 2 || len(t.Rows[0].Cells) < 2 {
-			colsDesc := "0"
-			if len(t.Rows) > 0 {
-				colsDesc = string(rune('0' + len(t.Rows[0].Cells)))
-			}
-			Logger.Debug("table rejected: too few rows/cols", "rows", len(t.Rows), "cols", colsDesc)
-			continue
-		}
-		hRatio, wRatio := t.BBox.Height()/pageRect.Height(), t.BBox.Width()/pageRect.Width()
-		if hRatio > 0.95 || wRatio > 0.98 {
-			Logger.Debug("table rejected: too large", "hRatio", hRatio, "wRatio", wRatio)
-			continue
-		}
-		garbage := false
-		for ri, row := range t.Rows {
-			if len(row.Cells) < 2 {
-				continue
-			}
-			var minH, maxH float32 = 1e6, 0
-			cellCount := 0
-			for _, cell := range row.Cells {
-				if !cell.BBox.IsEmpty() {
-					h := cell.BBox.Height()
-					if h < minH {
-						minH = h
-					}
-					if h > maxH {
-						maxH = h
-					}
-					cellCount++
-				}
-			}
-			if cellCount < 2 || minH <= 0 {
-				continue
-			}
-			ratio := maxH / minH
-			// Tables often have cells with multi-line text content
-			// Header rows can have merged cells with varying heights
-			// Allow higher ratio for header (ri==0) and second row which may contain sub-headers
-			threshold := float32(6.0)
-			if ri <= 1 {
-				threshold = 8.0
-			}
-			if ratio > threshold {
-				Logger.Debug("table rejected: garbage row", "rowIndex", ri, "minH", minH, "maxH", maxH)
-				garbage = true
-				break
-			}
-		}
-		if garbage {
-			continue
-		}
-		totalCells := 0
-		for _, row := range t.Rows {
-			for _, cell := range row.Cells {
-				if !cell.BBox.IsEmpty() {
-					totalCells++
-				}
-			}
-		}
-		if len(t.Rows) > 10 && totalCells < len(t.Rows)*2 {
-			Logger.Debug("table rejected: too sparse", "rows", len(t.Rows), "totalCells", totalCells)
-			continue
-		}
-		validRows, expectedCols, missingRows := 0, -1, 0
-		for _, row := range t.Rows {
-			if len(row.Cells) == 0 {
-				continue
-			}
-			validRows++
-			if expectedCols < 0 {
-				expectedCols = len(row.Cells)
-			} else if len(row.Cells) < expectedCols {
-				missingRows++
-			}
-		}
-		if validRows > 0 && float32(missingRows) > float32(validRows)*0.4 {
-			Logger.Debug("table rejected: too many missing rows", "missingRows", missingRows, "validRows", validRows)
-			continue
-		}
-		if validRows >= 2 && expectedCols >= 2 {
-			valid = append(valid, t)
+func tableBBoxFromRowsForTrim(rows []Row) geometry.Rect {
+	var bbox geometry.Rect
+	for _, row := range rows {
+		if bbox.IsEmpty() {
+			bbox = row.BBox
 		} else {
-			Logger.Debug("table rejected: final check failed", "validRows", validRows, "expectedCols", expectedCols)
+			bbox = bbox.Union(row.BBox)
 		}
 	}
-	tables.Tables = valid
+	return bbox
 }
 
-func ShrinkCellsToContent(tables *TableArray, chars []rawdata.Char) {
-	if tables == nil || len(chars) == 0 {
+func shouldPreserveEmptyColumns(tbl Table) bool {
+	if len(tbl.Rows) < 2 {
+		return false
+	}
+	lastCol := len(tbl.Rows[0].Cells) - 1
+	if lastCol <= 0 {
+		return false
+	}
+	for _, row := range tbl.Rows {
+		if len(row.Cells) <= lastCol {
+			return false
+		}
+		if row.Cells[lastCol].BBox.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+func splitTableOnSparseRowRuns(tbl Table, pageRect geometry.Rect) []Table {
+	if len(tbl.Rows) < 10 {
+		return []Table{tbl}
+	}
+	dominantCols := dominantRowCellCount(tbl.Rows)
+	if dominantCols < 4 {
+		return []Table{tbl}
+	}
+	tableWidth := tbl.BBox.Width()
+	if tableWidth <= 0 {
+		return []Table{tbl}
+	}
+	gapThreshold := adaptiveIntraTableGapThreshold(tbl.Rows, pageRect)
+	start := 0
+	var segments []Table
+	for i := 2; i < len(tbl.Rows)-2; {
+		if !isSparseSeparatorRow(tbl.Rows[i], dominantCols, tableWidth) {
+			i++
+			continue
+		}
+		j := i
+		for j < len(tbl.Rows)-1 && isSparseSeparatorRow(tbl.Rows[j], dominantCols, tableWidth) {
+			j++
+		}
+		leftStart := i - 4
+		leftStart = max(leftStart, start)
+		rightEnd := j + 4
+		rightEnd = min(rightEnd, len(tbl.Rows))
+		leftDense := denseRowRatio(tbl.Rows[leftStart:i], dominantCols) >= 0.55
+		rightDense := denseRowRatio(tbl.Rows[j:rightEnd], dominantCols) >= 0.55
+		gapBefore := float32(0)
+		if i > 0 {
+			gapBefore = tbl.Rows[i].BBox.Y0 - tbl.Rows[i-1].BBox.Y1
+		}
+		gapAfter := float32(0)
+		if j < len(tbl.Rows) {
+			gapAfter = tbl.Rows[j].BBox.Y0 - tbl.Rows[j-1].BBox.Y1
+		}
+		gapAround := geometry.Max32(gapBefore, gapAfter)
+		separatorRun := j - i
+		if leftDense && rightDense && (separatorRun >= 2 || gapAround >= gapThreshold) {
+			if i-start >= 2 {
+				rows := append([]Row(nil), tbl.Rows[start:i]...)
+				segments = append(segments, Table{Rows: rows, BBox: tableBBoxFromRowsForTrim(rows)})
+			}
+			start = j
+			i = j + 1
+			continue
+		}
+		i = j + 1
+	}
+	if len(tbl.Rows)-start >= 2 {
+		rows := append([]Row(nil), tbl.Rows[start:]...)
+		segments = append(segments, Table{Rows: rows, BBox: tableBBoxFromRowsForTrim(rows)})
+	}
+	if len(segments) <= 1 {
+		return []Table{tbl}
+	}
+	Logger.Debug("split table on sparse separator rows", "parts", len(segments), "rows", len(tbl.Rows), "dominantCols", dominantCols)
+	return segments
+}
+
+func dominantRowCellCount(rows []Row) int {
+	counts := make(map[int]int)
+	bestCols := 0
+	bestCount := 0
+	for _, row := range rows {
+		cols := len(row.Cells)
+		if cols <= 0 {
+			continue
+		}
+		counts[cols]++
+		if counts[cols] > bestCount {
+			bestCount = counts[cols]
+			bestCols = cols
+		}
+	}
+	return bestCols
+}
+
+func adaptiveIntraTableGapThreshold(rows []Row, pageRect geometry.Rect) float32 {
+	gaps := make([]float32, 0, len(rows)-1)
+	for i := 1; i < len(rows); i++ {
+		gap := rows[i].BBox.Y0 - rows[i-1].BBox.Y1
+		if gap > 0 {
+			gaps = append(gaps, gap)
+		}
+	}
+	base := pageRect.Height() * 0.009
+	if len(gaps) == 0 {
+		return base
+	}
+	slices.Sort(gaps)
+	medianGap := gaps[len(gaps)/2]
+	threshold := geometry.Max32(base, medianGap*2.2)
+	maxThreshold := pageRect.Height() * 0.055
+	if threshold > maxThreshold {
+		threshold = maxThreshold
+	}
+	return threshold
+}
+
+func isSparseSeparatorRow(row Row, dominantCols int, tableWidth float32) bool {
+	rowCols := len(row.Cells)
+	if rowCols <= 0 {
+		return true
+	}
+	maxCols := dominantCols / 3
+	maxCols = max(maxCols, 1)
+	if rowCols > maxCols {
+		return false
+	}
+	return row.BBox.Width()/tableWidth >= 0.35
+}
+
+func denseRowRatio(rows []Row, dominantCols int) float32 {
+	if len(rows) == 0 {
+		return 0
+	}
+	minDense := dominantCols - 1
+	minDense = max(minDense, 2)
+	dense := 0
+	for _, row := range rows {
+		if len(row.Cells) >= minDense {
+			dense++
+		}
+	}
+	return float32(dense) / float32(len(rows))
+}
+
+func (tables *TableArray) normalizeColumns(pageRect geometry.Rect) {
+	if tables.isEmpty() {
 		return
 	}
 	for ti := range tables.Tables {
 		tbl := &tables.Tables[ti]
-		rect := tbl.BBox
-		var tblChars []rawdata.Char
-		for _, ch := range chars {
-			if ch.BBox.X0 < rect.X1+2 && ch.BBox.X1 > rect.X0-2 && ch.BBox.Y0 < rect.Y1+2 && ch.BBox.Y1 > rect.Y0-2 {
-				tblChars = append(tblChars, ch)
-			}
-		}
-		if len(tblChars) == 0 {
-			continue
-		}
-		for ri := range tbl.Rows {
-			for ci := range tbl.Rows[ri].Cells {
-				cell := &tbl.Rows[ri].Cells[ci]
-				if cell.BBox.IsEmpty() {
-					continue
-				}
-				search := geometry.Rect{X0: cell.BBox.X0 - 2, Y0: cell.BBox.Y0 - 2, X1: cell.BBox.X1 + 2, Y1: cell.BBox.Y1 + 2}
-				var content geometry.Rect
-				first := true
-				for _, ch := range tblChars {
-					if ch.BBox.X0 < search.X1 && ch.BBox.X1 > search.X0 && ch.BBox.Y0 < search.Y1 && ch.BBox.Y1 > search.Y0 {
-						cr := geometry.Rect{X0: ch.BBox.X0, Y0: ch.BBox.Y0, X1: ch.BBox.X1, Y1: ch.BBox.Y1}
-						if first {
-							content, first = cr, false
-						} else {
-							content = content.Union(cr)
-						}
-					}
-				}
-				if !first {
-					cell.BBox.X0 = geometry.Max32(cell.BBox.X0, content.X0)
-					cell.BBox.Y0 = geometry.Max32(cell.BBox.Y0, content.Y0)
-					cell.BBox.X1 = geometry.Min32(cell.BBox.X1, content.X1)
-					cell.BBox.Y1 = geometry.Min32(cell.BBox.Y1, content.Y1)
-				}
-			}
-		}
+		grid := NewTableGrid(tbl)
+		grid.Normalize(GridNormalizeOptions{NormalizeColumns: true, PreserveEmptyColumns: shouldPreserveEmptyColumns(*tbl), PageRect: pageRect})
 	}
 }
 
@@ -498,7 +424,7 @@ func mergeEdges(edges []Edge, snapTol, joinTol float64) []Edge {
 		return nil
 	}
 	orientation := edges[0].Orientation
-	if orientation == 'h' {
+	if orientation == rawdata.EdgeHorizontal {
 		sort.Slice(edges, func(i, j int) bool {
 			if edges[i].Y0 != edges[j].Y0 {
 				return edges[i].Y0 < edges[j].Y0
@@ -514,20 +440,20 @@ func mergeEdges(edges []Edge, snapTol, joinTol float64) []Edge {
 		})
 	}
 	var result []Edge
-	snapInt, joinInt := coordToInt(snapTol), coordToInt(joinTol)
+	snapInt, joinInt := cordToInt(snapTol), cordToInt(joinTol)
 	for i := 0; i < len(edges); {
 		cur := edges[i]
-		posSum := coordToInt(cur.Y0)
-		if orientation == 'v' {
-			posSum = coordToInt(cur.X0)
+		posSum := cordToInt(cur.Y0)
+		if orientation == rawdata.EdgeVertical {
+			posSum = cordToInt(cur.X0)
 		}
 		count := 1
 		i++
 		for i < len(edges) {
 			next := edges[i]
-			nextPos := coordToInt(next.Y0)
-			if orientation == 'v' {
-				nextPos = coordToInt(next.X0)
+			nextPos := cordToInt(next.Y0)
+			if orientation == rawdata.EdgeVertical {
+				nextPos = cordToInt(next.X0)
 			}
 			if int(math.Abs(float64(nextPos-posSum/count))) <= snapInt {
 				posSum += nextPos
@@ -537,9 +463,9 @@ func mergeEdges(edges []Edge, snapTol, joinTol float64) []Edge {
 				break
 			}
 		}
-		snapped := float64(posSum/count) / coordScale
+		snapped := float64(posSum/count) / cordScale
 		joined := cur
-		if orientation == 'h' {
+		if orientation == rawdata.EdgeHorizontal {
 			joined.Y0, joined.Y1 = snapped, snapped
 		} else {
 			joined.X0, joined.X1 = snapped, snapped
@@ -547,9 +473,9 @@ func mergeEdges(edges []Edge, snapTol, joinTol float64) []Edge {
 		start := i - count
 		for j := start + 1; j < i; j++ {
 			next := edges[j]
-			if orientation == 'h' {
+			if orientation == rawdata.EdgeHorizontal {
 				next.Y0, next.Y1 = snapped, snapped
-				if coordToInt(next.X0)-coordToInt(joined.X1) <= joinInt {
+				if cordToInt(next.X0)-cordToInt(joined.X1) <= joinInt {
 					joined.X1 = math.Max(joined.X1, next.X1)
 				} else {
 					result = append(result, joined)
@@ -557,7 +483,7 @@ func mergeEdges(edges []Edge, snapTol, joinTol float64) []Edge {
 				}
 			} else {
 				next.X0, next.X1 = snapped, snapped
-				if coordToInt(next.Y0)-coordToInt(joined.Y1) <= joinInt {
+				if cordToInt(next.Y0)-cordToInt(joined.Y1) <= joinInt {
 					joined.Y1 = math.Max(joined.Y1, next.Y1)
 				} else {
 					result = append(result, joined)
@@ -570,173 +496,45 @@ func mergeEdges(edges []Edge, snapTol, joinTol float64) []Edge {
 	return result
 }
 
-func findIntersections(vEdges, hEdges []Edge, tr *rtree.RTreeG[geometry.Point], eps float64) {
-	tolInt := coordToInt(eps)
-	for _, v := range vEdges {
-		vXInt, vY0Int, vY1Int := coordToInt(v.X0), coordToInt(v.Y0), coordToInt(v.Y1)
-		for _, h := range hEdges {
-			hYInt := coordToInt(h.Y0)
-			if hYInt < vY0Int-tolInt || hYInt > vY1Int+tolInt {
-				continue
-			}
-			hX0Int, hX1Int := coordToInt(h.X0), coordToInt(h.X1)
-			if hX0Int-tolInt <= vXInt && hX1Int+tolInt >= vXInt {
-				p := geometry.Point{X: float32(v.X0), Y: float32(h.Y0)}
-				exists := false
-				tr.Search([2]float64{float64(p.X - 0.1), float64(p.Y - 0.1)}, [2]float64{float64(p.X + 0.1), float64(p.Y + 0.1)}, func(_, _ [2]float64, _ geometry.Point) bool {
-					exists = true
-					return false
-				})
-				if !exists {
-					tr.Insert([2]float64{float64(p.X), float64(p.Y)}, [2]float64{float64(p.X), float64(p.Y)}, p)
-				}
-			}
+func computeAvgCharWidth(chars []rawdata.Char) float32 {
+	var total float32
+	var count int
+	for _, ch := range chars {
+		w := ch.BBox.X1 - ch.BBox.X0
+		if w > 1 && w < 100 {
+			total += w
+			count++
 		}
 	}
+	if count == 0 {
+		return 5.0
+	}
+	return total / float32(count)
 }
 
-func isPunctOrDigit(r rune) bool {
-	return r == '.' || r == ',' || r == '$' || r == '%' || r == ':' || r == ';' || r == '\'' || r == '"' || r == '-' || r == '(' || r == ')' || (r >= '0' && r <= '9')
-}
-
-func extractTextInRect(raw *rawdata.PageData, rect geometry.Rect) string {
-	var buf strings.Builder
-	var prevX1, prevY0 float32 = -1000, -1000
-	var prevR rune
-	for i := range raw.Chars {
-		ch := &raw.Chars[i]
-		cx, cy := (ch.BBox.X0+ch.BBox.X1)/2, (ch.BBox.Y0+ch.BBox.Y1)/2
-		if cx < rect.X0-2 || cx > rect.X1+2 || cy < rect.Y0-2 || cy > rect.Y1+2 || ch.Codepoint == 0 || ch.Codepoint == 0xFEFF {
-			continue
-		}
-		if buf.Len() > 0 {
-			yDiff, xGap := math.Abs(float64(ch.BBox.Y0-prevY0)), float64(ch.BBox.X0-prevX1)
-			xTol, yTol := math.Max(float64(ch.Size*0.5), 3.0), math.Max(float64(ch.Size*0.3), 2.0)
-			if isPunctOrDigit(ch.Codepoint) || isPunctOrDigit(prevR) {
-				xTol, yTol = math.Max(xTol, 8.0), math.Max(yTol, 10.0)
-			}
-			if yDiff > yTol || xGap > xTol {
-				buf.WriteByte(' ')
-			}
-		}
-		buf.WriteRune(ch.Codepoint)
-		prevX1, prevY0, prevR = ch.BBox.X1, ch.BBox.Y0, ch.Codepoint
-	}
-	res := buf.String()
-	res = strings.TrimSpace(res)
-	res = strings.ReplaceAll(res, "\u00A0", " ")
-	var prev rune
-	var cleaned strings.Builder
-	for _, r := range res {
-		if r == ' ' && prev == ' ' {
-			continue
-		}
-		cleaned.WriteRune(r)
-		prev = r
-	}
-	return cleaned.String()
-}
-
-func extractTextIntoCells(raw *rawdata.PageData, tables *TableArray) {
-	if tables == nil {
-		return
-	}
-	for ti := range tables.Tables {
-		for ri := range tables.Tables[ti].Rows {
-			for ci := range tables.Tables[ti].Rows[ri].Cells {
-				tables.Tables[ti].Rows[ri].Cells[ci].Text = extractTextInRect(raw, tables.Tables[ti].Rows[ri].Cells[ci].BBox)
-			}
+func computeAvgEdgeSpacing(hEdges, vEdges []Edge) float64 {
+	var totalDist float64
+	var count int
+	sort.Slice(hEdges, func(i, j int) bool { return hEdges[i].Y0 < hEdges[j].Y0 })
+	for i := 1; i < len(hEdges); i++ {
+		dist := math.Abs(hEdges[i].Y0 - hEdges[i-1].Y0)
+		if dist > 1.0 {
+			totalDist += dist
+			count++
 		}
 	}
-}
-
-func convertTableRows(tbl Table) ([]models.TableRow, int) {
-	var rows []models.TableRow
-	visibleRows := 0
-	for _, r := range tbl.Rows {
-		var cells []models.TableCell
-		hasVisible := false
-		for _, c := range r.Cells {
-			if c.BBox.IsEmpty() {
-				continue
-			}
-			var spans []models.Span
-			if trimmed := strings.TrimSpace(c.Text); trimmed != "" {
-				spans, hasVisible = append(spans, models.Span{Text: trimmed}), true
-			}
-			cells = append(cells, models.TableCell{BBox: models.BBox{c.BBox.X0, c.BBox.Y0, c.BBox.X1, c.BBox.Y1}, Spans: spans})
-		}
-		if len(cells) > 0 {
-			rows = append(rows, models.TableRow{BBox: models.BBox{r.BBox.X0, r.BBox.Y0, r.BBox.X1, r.BBox.Y1}, Cells: cells})
-			if hasVisible {
-				visibleRows++
-			}
+	sort.Slice(vEdges, func(i, j int) bool { return vEdges[i].X0 < vEdges[j].X0 })
+	for i := 1; i < len(vEdges); i++ {
+		dist := math.Abs(vEdges[i].X0 - vEdges[i-1].X0)
+		if dist > 1.0 {
+			totalDist += dist
+			count++
 		}
 	}
-	if len(rows) > 0 {
-		normalizeHeaderRow(&rows)
+	if count == 0 {
+		return 10.0
 	}
-	return rows, visibleRows
-}
-
-func normalizeHeaderRow(rows *[]models.TableRow) {
-	if len(*rows) == 0 {
-		return
-	}
-	header := &(*rows)[0]
-	nonEmpty := make([]models.TableCell, 0, len(header.Cells))
-	for _, cell := range header.Cells {
-		for _, span := range cell.Spans {
-			if strings.TrimSpace(span.Text) != "" {
-				nonEmpty = append(nonEmpty, cell)
-				break
-			}
-		}
-	}
-	header.Cells = nonEmpty
-	colCount := len(nonEmpty)
-	for i := 1; i < len(*rows); i++ {
-		row := &(*rows)[i]
-		if len(row.Cells) > colCount {
-			row.Cells = row.Cells[:colCount]
-		} else if len(row.Cells) < colCount {
-			padded := make([]models.TableCell, colCount)
-			copy(padded, row.Cells)
-			row.Cells = padded
-		}
-	}
-}
-
-func ExtractAndConvertTables(raw *rawdata.PageData) []models.Block {
-	if len(raw.Edges) == 0 {
-		return nil
-	}
-	Logger.Debug("extracting tables", "page", raw.PageNumber, "edges", len(raw.Edges))
-	pageRect := geometry.Rect{X0: raw.PageBounds.X0, Y0: raw.PageBounds.Y0, X1: raw.PageBounds.X1, Y1: raw.PageBounds.Y1}
-	tables := detectTables(raw.Edges, pageRect, raw.PageNumber)
-	if tables == nil || len(tables.Tables) == 0 {
-		Logger.Debug("no tables detected")
-		return nil
-	}
-	Logger.Debug("detected tables", "count", len(tables.Tables))
-	ShrinkCellsToContent(tables, raw.Chars)
-	extractTextIntoCells(raw, tables)
-	var blocks []models.Block
-	for _, tbl := range tables.Tables {
-		rows, visibleRows := convertTableRows(tbl)
-		if visibleRows > 0 && len(rows) > 0 && len(rows[0].Cells) > 0 {
-			blocks = append(blocks, models.Block{
-				Type:      models.BlockTable,
-				BBox:      models.BBox{tbl.BBox.X0, tbl.BBox.Y0, tbl.BBox.X1, tbl.BBox.Y1},
-				RowCount:  visibleRows,
-				ColCount:  len(rows[0].Cells),
-				CellCount: visibleRows * len(rows[0].Cells),
-				Rows:      rows,
-			})
-		}
-	}
-	Logger.Debug("table extraction complete", "blocks", len(blocks))
-	return blocks
+	return totalDist / float64(count)
 }
 
 func detectTables(bridgeEdges []rawdata.Edge, pageRect geometry.Rect, pageNum int) *TableArray {
@@ -745,11 +543,11 @@ func detectTables(bridgeEdges []rawdata.Edge, pageRect geometry.Rect, pageNum in
 	}
 	var hEdges, vEdges []Edge
 	for _, e := range bridgeEdges {
-		edge := Edge{X0: e.X0, Y0: e.Y0, X1: e.X1, Y1: e.Y1, Orientation: byte(e.Orientation)}
-		if e.Orientation == rawdata.EdgeHorizontal {
-			hEdges = append(hEdges, edge)
-		} else {
-			vEdges = append(vEdges, edge)
+		switch e.Orientation {
+		case rawdata.EdgeHorizontal:
+			hEdges = append(hEdges, e)
+		case rawdata.EdgeVertical:
+			vEdges = append(vEdges, e)
 		}
 	}
 	pw := float64(pageRect.Width())
@@ -757,23 +555,12 @@ func detectTables(bridgeEdges []rawdata.Edge, pageRect geometry.Rect, pageNum in
 	hEdges = mergeEdges(hEdges, snapTol, joinTol)
 	vEdges = mergeEdges(vEdges, snapTol, joinTol)
 	Logger.Debug("merged edges", "page", pageNum, "hEdges", len(hEdges), "vEdges", len(vEdges))
-	if len(hEdges) < 3 || len(vEdges) < 3 {
+	if len(hEdges) < minHEdges || len(vEdges) < minVEdges {
 		return nil
 	}
-	ph := float64(pageRect.Height())
-	eps := math.Sqrt(pw*pw+ph*ph) * intersectRatio
-	var tr rtree.RTreeG[geometry.Point]
-	findIntersections(vEdges, hEdges, &tr, eps)
-	var points []geometry.Point
-	tr.Scan(func(_, _ [2]float64, value geometry.Point) bool {
-		points = append(points, value)
-		return true
-	})
-	Logger.Debug("found intersection points", "page", pageNum, "count", len(points))
-	if len(points) < 4 {
-		return nil
-	}
-	cells := findCells(points, &tr, pageRect, hEdges, vEdges)
+	avgEdgeSpacing := computeAvgEdgeSpacing(hEdges, vEdges)
+	Logger.Debug("avg edge spacing", "page", pageNum, "spacing", avgEdgeSpacing)
+	cells := findCells(pageRect, hEdges, vEdges, avgEdgeSpacing)
 	Logger.Debug("found cells", "page", pageNum, "count", len(cells))
 	if len(cells) == 0 {
 		return nil
@@ -798,5 +585,12 @@ func detectTables(bridgeEdges []rawdata.Edge, pageRect geometry.Rect, pageNum in
 	}
 	valid = deduplicateCells(valid)
 	Logger.Debug("deduplicated cells", "page", pageNum, "validCells", len(valid))
-	return groupCellsIntoTables(valid, pageRect)
+	tables := groupCellsIntoTables(valid, pageRect)
+	if tables == nil {
+		return nil
+	}
+	for i := range tables.Tables {
+		tables.Tables[i].RuledTable = true
+	}
+	return tables
 }

--- a/go/internal/table/tableassembly.go
+++ b/go/internal/table/tableassembly.go
@@ -1,0 +1,256 @@
+package table
+
+import (
+	"math"
+	"slices"
+	"sort"
+
+	"github.com/fibrumpdf/go/internal/geometry"
+)
+
+// AssemblyConfig contains configuration for table assembly.
+type AssemblyConfig struct {
+	MinSplitGapRatio float32
+	RowGapMultiplier float32
+	MaxSplitGapRatio float32
+}
+
+// NewDefaultTableAssemblyConfig returns the default assembly configuration.
+func NewDefaultTableAssemblyConfig() AssemblyConfig {
+	return AssemblyConfig{
+		MinSplitGapRatio: 0.03,
+		RowGapMultiplier: 2.4,
+		MaxSplitGapRatio: splitGapRatio,
+	}
+}
+
+// RowGrouper builds rows from detected cells.
+type RowGrouper interface {
+	GroupRows(cells []geometry.Rect, pageRect geometry.Rect) []Row
+}
+
+// Segmenter splits rows into tables.
+type Segmenter interface {
+	Segment(rows []Row, pageRect geometry.Rect) []Table
+}
+
+// Assembler provides unified table assembly logic.
+type Assembler struct {
+	cfg        AssemblyConfig
+	rowGrouper RowGrouper
+	segmenter  Segmenter
+}
+
+// NewAssembler creates a new table assembler.
+func NewAssembler(cfg AssemblyConfig, rowGrouper RowGrouper, segmenter Segmenter) *Assembler {
+	return &Assembler{cfg: cfg, rowGrouper: rowGrouper, segmenter: segmenter}
+}
+
+// NewDefaultTableAssembler creates a default table assembler.
+func NewDefaultTableAssembler(cfg AssemblyConfig) *Assembler {
+	return NewAssembler(cfg, RowGrouperDefault{}, RowGapSegmenter{cfg: cfg})
+}
+
+// AssembleFromCells assembles tables from detected cells.
+func (ta *Assembler) AssembleFromCells(cells []geometry.Rect, pageRect geometry.Rect) *TableArray {
+	if len(cells) < 2 {
+		return nil
+	}
+	rows := ta.rowGrouper.GroupRows(cells, pageRect)
+	return ta.AssembleFromRows(rows, pageRect)
+}
+
+// AssembleFromRows assembles tables from pre-grouped rows.
+func (ta *Assembler) AssembleFromRows(rows []Row, pageRect geometry.Rect) *TableArray {
+	rows = filterEmptyRows(rows)
+	if len(rows) < 2 {
+		return nil
+	}
+	tables := ta.segmenter.Segment(rows, pageRect)
+	if len(tables) == 0 {
+		return nil
+	}
+	return &TableArray{Tables: tables}
+}
+
+// RowGrouperDefault groups cell rectangles into rows.
+type RowGrouperDefault struct{}
+
+// GroupRows groups cells into rows using a tolerance derived from average height.
+func (RowGrouperDefault) GroupRows(cells []geometry.Rect, pageRect geometry.Rect) []Row {
+	var avgH float32
+	for _, c := range cells {
+		avgH += c.Height()
+	}
+	avgH /= float32(len(cells))
+	rowGroupTol := adaptiveRowGroupingTolerance(avgH, pageRect)
+
+	rowHeights := make(map[float32][]geometry.Rect)
+	rowTol := avgH * 0.3
+	for _, c := range cells {
+		foundKey := float32(-1)
+		for key := range rowHeights {
+			if geometry.Abs32(c.Y0-key) < rowTol {
+				foundKey = key
+				break
+			}
+		}
+		if foundKey >= 0 {
+			rowHeights[foundKey] = append(rowHeights[foundKey], c)
+		} else {
+			rowHeights[c.Y0] = []geometry.Rect{c}
+		}
+	}
+
+	var rowYPositions []float32
+	for y := range rowHeights {
+		rowYPositions = append(rowYPositions, y)
+	}
+	slices.Sort(rowYPositions)
+
+	var heights []float32
+	for _, y := range rowYPositions {
+		if len(rowHeights[y]) > 0 {
+			h := rowHeights[y][0].Height()
+			for _, c := range rowHeights[y][1:] {
+				h = geometry.Max32(h, c.Height())
+			}
+			heights = append(heights, h)
+		}
+	}
+	if len(heights) >= 2 {
+		var sumH float32
+		for _, h := range heights {
+			sumH += h
+		}
+		avgRowH := sumH / float32(len(heights))
+		var filteredCells []geometry.Rect
+		for _, y := range rowYPositions {
+			rowCells := rowHeights[y]
+			var rowH float32
+			for _, c := range rowCells {
+				rowH = geometry.Max32(rowH, c.Height())
+			}
+			if avgRowH > 0 && rowH > 0 {
+				ratio := rowH / avgRowH
+				if ratio < 2.5 && ratio > 0.4 {
+					filteredCells = append(filteredCells, rowCells...)
+				} else {
+					Logger.Debug("filtered row by height consistency", "rowH", rowH, "avgRowH", avgRowH, "ratio", ratio)
+				}
+			} else {
+				filteredCells = append(filteredCells, rowCells...)
+			}
+		}
+		if len(filteredCells) < len(cells)*3/4 {
+			cells = filteredCells
+		}
+	}
+
+	sortTol := avgH * 0.2
+	sort.Slice(cells, func(i, j int) bool {
+		if dy := cells[i].Y0 - cells[j].Y0; geometry.Abs32(dy) > sortTol {
+			return dy < 0
+		}
+		return cells[i].X0 < cells[j].X0
+	})
+	var rows []Row
+	for i := 0; i < len(cells); {
+		rowY0, yTol := cells[i].Y0, rowGroupTol
+		j := i + 1
+		for j < len(cells) && math.Abs(float64(cells[j].Y0-rowY0)) <= float64(yTol) {
+			j++
+		}
+		rowCells := make([]Cell, j-i)
+		for k := 0; k < j-i; k++ {
+			rowCells[k].BBox = cells[i+k]
+		}
+		sort.Slice(rowCells, func(k1, k2 int) bool { return rowCells[k1].BBox.X0 < rowCells[k2].BBox.X0 })
+		row := Row{Cells: rowCells, BBox: rowCells[0].BBox}
+		for k := 1; k < len(rowCells); k++ {
+			row.BBox = row.BBox.Union(rowCells[k].BBox)
+		}
+		rows = append(rows, row)
+		i = j
+	}
+	return rows
+}
+
+// RowGapSegmenter segments rows into tables based on vertical gaps.
+type RowGapSegmenter struct {
+	cfg AssemblyConfig
+}
+
+// Segment splits rows into tables using gap thresholds and structural separators.
+func (s RowGapSegmenter) Segment(rows []Row, pageRect geometry.Rect) []Table {
+	splitGap := computeSplitGap(rows, pageRect, s.cfg)
+	var tables []Table
+	var cur Table
+	for i := 0; i < len(rows); i++ {
+		row := rows[i]
+		if len(cur.Rows) > 0 {
+			gap := row.BBox.Y0 - cur.Rows[len(cur.Rows)-1].BBox.Y1
+			if gap > splitGap {
+				if len(cur.Rows) >= 2 && !shouldRejectFullPageTable(cur, pageRect) {
+					tables = append(tables, cur)
+				}
+				cur = Table{}
+			}
+		}
+		cur.Rows = append(cur.Rows, row)
+		cur.BBox = cur.BBox.Union(row.BBox)
+	}
+	if len(cur.Rows) >= 2 && !shouldRejectFullPageTable(cur, pageRect) {
+		tables = append(tables, cur)
+	}
+	if len(tables) == 0 {
+		return nil
+	}
+	var segmented []Table
+	for _, tbl := range tables {
+		parts := splitTableOnSparseRowRuns(tbl, pageRect)
+		segmented = append(segmented, parts...)
+	}
+	return segmented
+}
+
+func filterEmptyRows(rows []Row) []Row {
+	filtered := rows[:0]
+	for _, row := range rows {
+		if len(row.Cells) == 0 || row.BBox.IsEmpty() {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	return filtered
+}
+
+func computeSplitGap(rows []Row, pageRect geometry.Rect, cfg AssemblyConfig) float32 {
+	var sumH float32
+	count := 0
+	for _, row := range rows {
+		h := row.BBox.Height()
+		if h > 0 {
+			sumH += h
+			count++
+		}
+	}
+	avgH := float32(0)
+	if count > 0 {
+		avgH = sumH / float32(count)
+	}
+	splitGap := geometry.Max32(pageRect.Height()*cfg.MinSplitGapRatio, avgH*cfg.RowGapMultiplier)
+	maxGap := pageRect.Height() * cfg.MaxSplitGapRatio
+	if splitGap > maxGap {
+		splitGap = maxGap
+	}
+	return splitGap
+}
+
+func shouldRejectFullPageTable(tbl Table, pageRect geometry.Rect) bool {
+	if pageRect.Height() <= 0 {
+		return false
+	}
+	tableHeight := tbl.BBox.Height()
+	return tableHeight/pageRect.Height() > 0.9 && len(tbl.Rows) > 10
+}

--- a/go/internal/table/tolerance.go
+++ b/go/internal/table/tolerance.go
@@ -1,0 +1,128 @@
+package table
+
+import "github.com/fibrumpdf/go/internal/geometry"
+
+// ToleranceConfig centralizes all proximity and tolerance checks
+type ToleranceConfig struct {
+	AlignmentTolerance       float32
+	RowYTolerance            float32
+	SegmentGapMultiplier     float32
+	SegmentGapMin            float32
+	ColumnAnchorMultiplier   float32
+	ColumnAnchorDensityBoost float32
+	ColumnAnchorMin          float32
+	RowClusterMultiplier     float32
+	RowClusterDensityBoost   float32
+	RowClusterMin            float32
+	WordGapMultiplier        float32
+	WordGapMin               float32
+	ColumnMergeMultiplier    float32
+	ColumnMergeGrowthFactor  float32
+	MaxColumnCount           int
+}
+
+// NewDefaultToleranceConfig returns the default tolerance configuration
+func NewDefaultToleranceConfig() ToleranceConfig {
+	return ToleranceConfig{
+		AlignmentTolerance:       3.0,
+		RowYTolerance:            3.0,
+		SegmentGapMultiplier:     1.8,
+		SegmentGapMin:            4.0,
+		ColumnAnchorMultiplier:   2.0,
+		ColumnAnchorDensityBoost: 50.0,
+		ColumnAnchorMin:          12.0,
+		RowClusterMultiplier:     0.005,
+		RowClusterDensityBoost:   20.0,
+		RowClusterMin:            3.0,
+		WordGapMultiplier:        1.6,
+		WordGapMin:               6.0,
+		ColumnMergeMultiplier:    3.8,
+		ColumnMergeGrowthFactor:  1.35,
+		MaxColumnCount:           16,
+	}
+}
+
+// Cluster1D maintains clustered 1D positions with counts.
+type Cluster1D struct {
+	Tol     float32
+	Centers []float32
+	Counts  []int
+}
+
+// NewCluster1D creates a new 1D cluster helper.
+func NewCluster1D(tol float32) *Cluster1D {
+	return &Cluster1D{Tol: tol}
+}
+func (c *Cluster1D) Add(value float32) int {
+	lastIdx := len(c.Centers) - 1
+
+	if lastIdx >= 0 {
+		diff := value - c.Centers[lastIdx]
+
+		if (diff >= 0 && diff <= c.Tol) || (diff < 0 && -diff <= c.Tol) {
+			oldCount := c.Counts[lastIdx]
+			newCount := oldCount + 1
+			c.Counts[lastIdx] = newCount
+
+			invCount := 1.0 / float32(newCount)
+			c.Centers[lastIdx] = (c.Centers[lastIdx]*float32(oldCount) + value) * invCount
+			return lastIdx
+		}
+	}
+
+	for i := lastIdx - 1; i >= 0; i-- {
+		diff := value - c.Centers[i]
+		if (diff >= 0 && diff <= c.Tol) || (diff < 0 && -diff <= c.Tol) {
+			oldCount := c.Counts[i]
+			newCount := oldCount + 1
+			c.Counts[i] = newCount
+			c.Centers[i] = (c.Centers[i]*float32(oldCount) + value) / float32(newCount)
+			return i
+		}
+	}
+
+	c.Centers = append(c.Centers, value)
+	c.Counts = append(c.Counts, 1)
+	return len(c.Centers) - 1
+}
+
+// MergeSorted collapses sorted values into clustered centers.
+func (c *Cluster1D) MergeSorted(values []float32) []float32 {
+	if len(values) < 2 {
+		return values
+	}
+	result := []float32{values[0]}
+	for i := 1; i < len(values); i++ {
+		if geometry.Abs32(values[i]-result[len(result)-1]) > c.Tol {
+			result = append(result, values[i])
+			continue
+		}
+		result[len(result)-1] = (result[len(result)-1] + values[i]) * 0.5
+	}
+	return result
+}
+
+// ComputeRowYTolerance computes row Y tolerance with optional multiplier
+func ComputeRowYTolerance(baseTol, multiplier float32) float32 {
+	return baseTol * multiplier
+}
+
+// ComputeSegmentGap computes segment gap tolerance from average character width
+func ComputeSegmentGap(avgCharWidth float32, cfg ToleranceConfig) float32 {
+	return geometry.Max32(avgCharWidth*cfg.SegmentGapMultiplier, cfg.SegmentGapMin)
+}
+
+// ComputeColumnAnchorTolerance computes the x tolerance for column anchors.
+func ComputeColumnAnchorTolerance(avgCharWidth, charDensity float32, cfg ToleranceConfig) float32 {
+	return geometry.Max32(avgCharWidth*(cfg.ColumnAnchorMultiplier+charDensity*cfg.ColumnAnchorDensityBoost), cfg.ColumnAnchorMin)
+}
+
+// ComputeRowClusterTolerance computes the y tolerance for row clustering.
+func ComputeRowClusterTolerance(pageHeight, charDensity float32, cfg ToleranceConfig) float32 {
+	return geometry.Max32(pageHeight*cfg.RowClusterMultiplier*(1.0+charDensity*cfg.RowClusterDensityBoost), cfg.RowClusterMin)
+}
+
+// ComputeWordGap computes the gap used to separate words on a line.
+func ComputeWordGap(avgCharWidth float32, cfg ToleranceConfig) float32 {
+	return geometry.Max32(avgCharWidth*cfg.WordGapMultiplier, cfg.WordGapMin)
+}

--- a/go/internal/table/types.go
+++ b/go/internal/table/types.go
@@ -1,0 +1,48 @@
+package table
+
+import (
+	"github.com/fibrumpdf/go/internal/geometry"
+	"github.com/fibrumpdf/go/internal/raw"
+)
+
+const (
+	snapTolRatio    = 0.015
+	joinTolRatio    = 0.005
+	minCellRatio    = 0.002  // Reduced from 0.003 to allow smaller cells
+	maxCellWRatio   = 0.95
+	maxCellHRatio   = 0.50
+	splitGapRatio   = 0.10
+	rowYTolRatio    = 0.015
+	colXTolRatio    = 0.003
+	intersectRatio  = 0.0015
+	cordScale       = 1000.0
+	minHEdges       = 2
+	minVEdges       = 2
+	maxEdgesForGrid = 320
+	heavyCharCount  = 3000
+)
+
+type Edge = raw.Edge
+
+type Cell struct {
+	BBox geometry.Rect
+	Text string
+}
+
+type Row struct {
+	BBox     geometry.Rect
+	Cells    []Cell
+	IsHeader bool // true if this row is part of a merged header group
+}
+
+type Table struct {
+	BBox       geometry.Rect
+	Rows       []Row
+	RuledTable bool // true when built from physical grid lines (hEdges+vEdges)
+}
+
+type TableArray struct{ Tables []Table }
+
+func (tables *TableArray) isEmpty() bool {
+	return tables == nil || len(tables.Tables) == 0
+}


### PR DESCRIPTION
It's not just a refactor, it's got a lot of logical changes, but, unfortunately, I've made so many changes over months and months I couldn't break it up very much. (note that many commits have been being made in the past week... it was iterations and iterations, finally finalized)

The below covers the refactoring side, but there are many (positive) changes that boost precision and recall. I've forgotten them by now, and, they're quite micro, so I couldn't cover them all in a read.

As a summary, we haven't removed any complexity, though, now it is more maintainable as each stage does one job, and, we also have some helpers; less duplicated logic.

- extract table extraction into distinct pipeline stages
  - detector: identify potential tables via grid-based analysis
  - materializer: extract cell content and structure
  - selector: filter valid tables based on criteria
  - converter: transform internal representation to output format

- introduce dedicated modules for clarity
  - grid.go: grid normalization and line finding logic
  - tolerance.go: tolerance thresholds (single source of truth)
  - tableassembly.go: cell merging and table structure assembly
  - types.go: internal type definitions for pipeline

- refactor table.go to use pipeline
  - simplify main extraction logic with clear data flow
  - reduce code duplication and special cases
  - improve testability with isolated stage logic
  